### PR TITLE
予定追加画面(表示)の実装

### DIFF
--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -8,4 +8,6 @@ class TextConstants {
   static const String scheduleCreateViewAppBarTitle = '予定追加';
   static const String scheduleCreateViewHintText = 'タイトルを入力してください';
   static const String scheduleCreateViewWholeDay = '終日';
+  static const String scheduleCreateViewStart = '開始';
+  static const String wholeDaySwitchOffDateFormat = 'yyyy-MM-dd HH:mm';
 }

--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -7,4 +7,5 @@ class TextConstants {
   // 予定の追加画面
   static const String scheduleCreateViewAppBarTitle = '予定追加';
   static const String scheduleCreateViewHintText = 'タイトルを入力してください';
+  static const String scheduleCreateViewWholeDay = '終日';
 }

--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -1,5 +1,9 @@
 class TextConstants {
+  // カレンダー画面
   static const String calendarViewAppBarTitle = 'カレンダー';
   static const String today = '今日';
   static const String calendarDateFormat = 'yyyy年MM月';
+
+  // 予定の追加画面
+  static const String scheduleCreateViewAppBarTitle = '予定追加';
 }

--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -6,9 +6,10 @@ class TextConstants {
 
   // 予定の追加画面
   static const String scheduleCreateViewAppBarTitle = '予定追加';
-  static const String scheduleCreateViewHintText = 'タイトルを入力してください';
+  static const String scheduleCreateViewTitleHintText = 'タイトルを入力してください';
   static const String scheduleCreateViewWholeDay = '終日';
   static const String scheduleCreateViewStart = '開始';
   static const String wholeDaySwitchOffDateFormat = 'yyyy-MM-dd HH:mm';
   static const String scheduleCreateViewEnd = '終了';
+  static const String scheduleCreateViewCommentHintText = 'コメントを入力してください';
 }

--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -6,4 +6,5 @@ class TextConstants {
 
   // 予定の追加画面
   static const String scheduleCreateViewAppBarTitle = '予定追加';
+  static const String scheduleCreateViewHintText = 'タイトルを入力してください';
 }

--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -12,4 +12,5 @@ class TextConstants {
   static const String wholeDaySwitchOffDateFormat = 'yyyy-MM-dd HH:mm';
   static const String scheduleCreateViewEnd = '終了';
   static const String scheduleCreateViewCommentHintText = 'コメントを入力してください';
+  static const String scheduleCreateViewSave = '保存';
 }

--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -10,4 +10,5 @@ class TextConstants {
   static const String scheduleCreateViewWholeDay = '終日';
   static const String scheduleCreateViewStart = '開始';
   static const String wholeDaySwitchOffDateFormat = 'yyyy-MM-dd HH:mm';
+  static const String scheduleCreateViewEnd = '終了';
 }

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:schedule_management_app/view/constants/text_constants.dart';
+
+class ScheduleCreateView extends StatelessWidget {
+  const ScheduleCreateView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(TextConstants.scheduleCreateViewAppBarTitle),
+        centerTitle: true,
+      ),
+    );
+  }
+}

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -11,6 +11,15 @@ class ScheduleCreateView extends StatelessWidget {
         title: const Text(TextConstants.scheduleCreateViewAppBarTitle),
         centerTitle: true,
       ),
+      body: Column(
+        children: const [
+          TextField(
+            decoration: InputDecoration(
+              hintText: TextConstants.scheduleCreateViewHintText,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -11,6 +11,16 @@ class ScheduleCreateView extends StatelessWidget {
       appBar: AppBar(
         title: const Text(TextConstants.scheduleCreateViewAppBarTitle),
         centerTitle: true,
+        actions: const [
+          Padding(
+            padding: EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              child: Text(TextConstants.scheduleCreateViewSave),
+              // TODO 保存ボタンをタップしたときの処理
+              onPressed: null,
+            ),
+          ),
+        ],
       ),
       body: Column(
         children: [

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -12,12 +12,24 @@ class ScheduleCreateView extends StatelessWidget {
         centerTitle: true,
       ),
       body: Column(
-        children: const [
-          TextField(
+        children: [
+          const TextField(
             autofocus: true,
             decoration: InputDecoration(
               hintText: TextConstants.scheduleCreateViewHintText,
             ),
+          ),
+          Row(
+            children: [
+              const Text(TextConstants.scheduleCreateViewWholeDay),
+              Switch(
+                  value: false,
+                  onChanged: (value) {
+                    // TODO 終日スイッチがオフの場合は、オンにする。
+                    // TODO 終日スイッチがオンの場合は、オフにする。
+                  },
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -14,6 +14,7 @@ class ScheduleCreateView extends StatelessWidget {
       body: Column(
         children: const [
           TextField(
+            autofocus: true,
             decoration: InputDecoration(
               hintText: TextConstants.scheduleCreateViewHintText,
             ),

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -17,7 +17,7 @@ class ScheduleCreateView extends StatelessWidget {
           const TextField(
             autofocus: true,
             decoration: InputDecoration(
-              hintText: TextConstants.scheduleCreateViewHintText,
+              hintText: TextConstants.scheduleCreateViewTitleHintText,
             ),
           ),
           Row(
@@ -34,6 +34,15 @@ class ScheduleCreateView extends StatelessWidget {
           ),
           buildDatePickerButton(TextConstants.scheduleCreateViewStart, DateTime.now()),
           buildDatePickerButton(TextConstants.scheduleCreateViewEnd, DateTime.now()),
+          const Expanded(
+            child: TextField(
+              decoration: InputDecoration(
+                hintText: TextConstants.scheduleCreateViewCommentHintText,
+              ),
+              keyboardType: TextInputType.multiline,
+              maxLines: null,
+            ),
+          ),
         ],
       ),
     );

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -11,6 +11,12 @@ class ScheduleCreateView extends StatelessWidget {
       appBar: AppBar(
         title: const Text(TextConstants.scheduleCreateViewAppBarTitle),
         centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
         actions: const [
           Padding(
             padding: EdgeInsets.all(8.0),

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -32,26 +32,31 @@ class ScheduleCreateView extends StatelessWidget {
               ),
             ],
           ),
-          Row(
-            children: [
-              const Text(TextConstants.scheduleCreateViewStart),
-              TextButton(
-                child: Text(
-                  // TODO 予定追加の場合は、選択された日付、現在の時間を表示する。
-                  DateFormat(TextConstants.wholeDaySwitchOffDateFormat).format(DateTime.now()),
-                  // TODO 終日スイッチがオンの場合は、「yyyy-MM-dd 」形式で表示する。
-                  style: const TextStyle(
-                    color: Colors.black,
-                  ),
-                ),
-                onPressed: () {
-                  // TODO 開始時間ピッカーの動作実装
-                },
-              ),
-            ],
-          ),
+          buildDatePickerButton(TextConstants.scheduleCreateViewStart, DateTime.now()),
+          buildDatePickerButton(TextConstants.scheduleCreateViewEnd, DateTime.now()),
         ],
       ),
+    );
+  }
+
+  Row buildDatePickerButton(String title, DateTime dateTime) {
+    return Row(
+      children: [
+        Text(title),
+        TextButton(
+          child: Text(
+            // TODO 予定追加の場合は、選択された日付、現在の時間を表示する。
+            DateFormat(TextConstants.wholeDaySwitchOffDateFormat).format(dateTime),
+            // TODO 終日スイッチがオンの場合は、「yyyy-MM-dd 」形式で表示する。
+            style: const TextStyle(
+              color: Colors.black,
+            ),
+          ),
+          onPressed: () {
+            // TODO 時間ピッカーの動作実装
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/view/view/schedule_create_view.dart
+++ b/lib/view/view/schedule_create_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:schedule_management_app/view/constants/text_constants.dart';
 
 class ScheduleCreateView extends StatelessWidget {
@@ -23,11 +24,29 @@ class ScheduleCreateView extends StatelessWidget {
             children: [
               const Text(TextConstants.scheduleCreateViewWholeDay),
               Switch(
-                  value: false,
-                  onChanged: (value) {
-                    // TODO 終日スイッチがオフの場合は、オンにする。
-                    // TODO 終日スイッチがオンの場合は、オフにする。
-                  },
+                value: false,
+                onChanged: (value) {
+                  // TODO 終日スイッチがオフの場合は、オンにする。
+                  // TODO 終日スイッチがオンの場合は、オフにする。
+                },
+              ),
+            ],
+          ),
+          Row(
+            children: [
+              const Text(TextConstants.scheduleCreateViewStart),
+              TextButton(
+                child: Text(
+                  // TODO 予定追加の場合は、選択された日付、現在の時間を表示する。
+                  DateFormat(TextConstants.wholeDaySwitchOffDateFormat).format(DateTime.now()),
+                  // TODO 終日スイッチがオンの場合は、「yyyy-MM-dd 」形式で表示する。
+                  style: const TextStyle(
+                    color: Colors.black,
+                  ),
+                ),
+                onPressed: () {
+                  // TODO 開始時間ピッカーの動作実装
+                },
               ),
             ],
           ),


### PR DESCRIPTION
## 概要
- 予定追加画面の実装
## Issue
- https://github.com/curitefl/schedule_management_app/issues/4

## 確認方法
carendar_view.dartに以下のように予定追加画面に遷移できるように処理を追加
```dart
appBar: AppBar(
        title: const Text(TextConstants.calendarViewAppBarTitle),
        centerTitle: true,
        // 仮で動作確認できるように以下のボタンを追加
        actions: [
          ElevatedButton(
            onPressed: () {
              Navigator.of(context).push(
                MaterialPageRoute(
                  builder: (context) {
                    return const ScheduleCreateView();
                  },
                ),
              );
            },
            child: const Text('移動'),
          ),
        ],
      ),
```

https://user-images.githubusercontent.com/103098702/165868149-4d175268-d25d-4cb5-bcda-eebd7d2332cb.mov


