### PR TITLE
日別予定一覧画面(表示)の実装

### DIFF
--- a/lib/view/constants/schedule_list_constants.dart
+++ b/lib/view/constants/schedule_list_constants.dart
@@ -1,0 +1,3 @@
+class ScheduleListConstants {
+  static const String scheduleListLocale = 'ja_JP';
+}

--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -13,4 +13,7 @@ class TextConstants {
   static const String scheduleCreateViewEnd = '終了';
   static const String scheduleCreateViewCommentHintText = 'コメントを入力してください';
   static const String scheduleCreateViewSave = '保存';
+
+  // 日別予定一覧画面
+  static const String scheduleListViewDateFormat = 'yyyy/MM/dd (E)';
 }

--- a/lib/view/constants/text_constants.dart
+++ b/lib/view/constants/text_constants.dart
@@ -16,4 +16,5 @@ class TextConstants {
 
   // 日別予定一覧画面
   static const String scheduleListViewDateFormat = 'yyyy/MM/dd (E)';
+  static const String scheduleListViewTimeFormat = 'HH:mm';
 }

--- a/lib/view/view/schedule_list_view.dart
+++ b/lib/view/view/schedule_list_view.dart
@@ -50,6 +50,7 @@ class ScheduleListView extends StatelessWidget {
                     ).format(DateTime.now()),),
                   ],
                 ),
+                const Text('スケジュールタイトル'),
               ],
             ),
           ],

--- a/lib/view/view/schedule_list_view.dart
+++ b/lib/view/view/schedule_list_view.dart
@@ -32,6 +32,29 @@ class ScheduleListView extends StatelessWidget {
           ),
         ],
       ),
+      children: [
+        Column(
+          // TODO for文で回す
+          children: [
+            Row(
+              children: [
+                Column(
+                  children: [
+                    Text(DateFormat(
+                      TextConstants.scheduleListViewTimeFormat,
+                      ScheduleListConstants.scheduleListLocale,
+                    ).format(DateTime.now()),),
+                    Text(DateFormat(
+                      TextConstants.scheduleListViewTimeFormat,
+                      ScheduleListConstants.scheduleListLocale,
+                    ).format(DateTime.now()),),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(
           Radius.circular(20.0),

--- a/lib/view/view/schedule_list_view.dart
+++ b/lib/view/view/schedule_list_view.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:schedule_management_app/view/constants/schedule_list_constants.dart';
+import 'package:schedule_management_app/view/constants/text_constants.dart';
+
+class ScheduleListView extends StatelessWidget {
+  const ScheduleListView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialog(
+      title: Text(
+        DateFormat(
+          TextConstants.scheduleListViewDateFormat,
+          ScheduleListConstants.scheduleListLocale,
+        ).format(DateTime.now()),
+      ),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(
+          Radius.circular(20.0),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/view/schedule_list_view.dart
+++ b/lib/view/view/schedule_list_view.dart
@@ -10,11 +10,27 @@ class ScheduleListView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SimpleDialog(
-      title: Text(
-        DateFormat(
-          TextConstants.scheduleListViewDateFormat,
-          ScheduleListConstants.scheduleListLocale,
-        ).format(DateTime.now()),
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            DateFormat(
+              TextConstants.scheduleListViewDateFormat,
+              ScheduleListConstants.scheduleListLocale,
+            ).format(DateTime.now()),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          IconButton(
+            icon: const Icon(
+              Icons.add,
+              color: Colors.blue,
+            ),
+            onPressed: () {
+              // TODO 予定追加画面を表示する
+            },
+          ),
+        ],
       ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(


### PR DESCRIPTION
## 概要
- 日別予定一覧画面の実装

## Issue
- https://github.com/curitefl/schedule_management_app/issues/11

## 確認方法
carendar_view.dartに以下のように日別予定一覧画面を表示できるように処理を追加
```dart
appBar: AppBar(
        title: const Text(TextConstants.calendarViewAppBarTitle),
        centerTitle: true,
        // 仮で動作確認できるように以下のボタンを追加
        actions: [
          ElevatedButton(
            onPressed: () {
              showDialog(
                  context: context,
                  builder: (builder) {
                    return const ScheduleListView();
                  },
              );
            },
            child: const Text('移動'),
          ),
        ],
      ),
```

https://user-images.githubusercontent.com/103098702/165894758-e9ceca7a-ef62-4430-92ba-a7056a8ca3b9.mov


