### PR TITLE
予定編集画面（表示、動作）の実装

### DIFF
--- a/lib/data/repository/schedule_repository.dart
+++ b/lib/data/repository/schedule_repository.dart
@@ -5,16 +5,16 @@ class ScheduleRepository {
 
   ScheduleRepository(final this._calendarDataStore);
 
-  Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
-    return _calendarDataStore.getMonthScheduleEntries(dateTime);
+  Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) async {
+    return await _calendarDataStore.getMonthScheduleEntries(dateTime);
   }
 
-  Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {
-    return _calendarDataStore.getDayScheduleEntries(dateTime);
+  Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) async {
+    return await _calendarDataStore.getDayScheduleEntries(dateTime);
   }
 
-  Future<Schedule> getScheduleEntry(final int scheduleId) {
-    return _calendarDataStore.getScheduleEntry(scheduleId);
+  Future<Schedule> getScheduleEntry(final int scheduleId) async {
+    return await _calendarDataStore.getScheduleEntry(scheduleId);
   }
 
   Future<void> addSchedule(
@@ -23,12 +23,12 @@ class ScheduleRepository {
     final DateTime startDateTime,
     final DateTime endDateTime,
     final String description,
-  ) {
-    return _calendarDataStore.addSchedule(
+  ) async {
+    await _calendarDataStore.addSchedule(
         title, isWholeDay, startDateTime, endDateTime, description);
   }
 
-  Future<int> updateSchedule(
+  Future<void> updateSchedule(
     final int scheduleId,
     final String title,
     final bool isWholeDay,
@@ -36,17 +36,14 @@ class ScheduleRepository {
     final DateTime endDateTime,
     final String description,
   ) async {
-    final schedule = await _getSchedule(scheduleId);
-    return _calendarDataStore.updateSchedule(
+    final schedule = await getScheduleEntry(scheduleId);
+
+    await _calendarDataStore.updateSchedule(
         schedule, title, isWholeDay, startDateTime, endDateTime, description);
   }
 
-  Future<void> deleteSchedule(final int id) async {
-    final schedule = await _getSchedule(id);
-    return _calendarDataStore.deleteSchedule(schedule);
-  }
-
-  Future<Schedule> _getSchedule(final int scheduleId) {
-    return _calendarDataStore.getScheduleEntry(scheduleId);
+  Future<void> deleteSchedule(final int scheduleId) async {
+    final schedule = await getScheduleEntry(scheduleId);
+    await _calendarDataStore.deleteSchedule(schedule);
   }
 }

--- a/lib/data/repository/schedule_repository.dart
+++ b/lib/data/repository/schedule_repository.dart
@@ -5,12 +5,12 @@ class ScheduleRepository {
 
   ScheduleRepository(final this._calendarDataStore);
 
-  Future<List<Schedule>> getMonthScheduleEntries(final int year, final int month) {
-    return _calendarDataStore.getMonthScheduleEntries(year, month);
+  Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
+    return _calendarDataStore.getMonthScheduleEntries(dateTime);
   }
 
-  Future<List<Schedule>> getDayScheduleEntries(final int year, final int month, final int day) {
-    return _calendarDataStore.getDayScheduleEntries(year, month, day);
+  Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {
+    return _calendarDataStore.getDayScheduleEntries(dateTime);
   }
 
   Future addSchedule(

--- a/lib/data/repository/schedule_repository.dart
+++ b/lib/data/repository/schedule_repository.dart
@@ -17,7 +17,7 @@ class ScheduleRepository {
     return _calendarDataStore.getScheduleEntry(scheduleId);
   }
 
-  Future addSchedule(
+  Future<void> addSchedule(
     final String title,
     final bool isWholeDay,
     final DateTime startDateTime,
@@ -28,7 +28,7 @@ class ScheduleRepository {
         title, isWholeDay, startDateTime, endDateTime, description);
   }
 
-  Future updateSchedule(
+  Future<int> updateSchedule(
     final int scheduleId,
     final String title,
     final bool isWholeDay,
@@ -41,7 +41,7 @@ class ScheduleRepository {
         schedule, title, isWholeDay, startDateTime, endDateTime, description);
   }
 
-  Future deleteSchedule(final int id) async {
+  Future<void> deleteSchedule(final int id) async {
     final schedule = await _getSchedule(id);
     return _calendarDataStore.deleteSchedule(schedule);
   }

--- a/lib/data/repository/schedule_repository.dart
+++ b/lib/data/repository/schedule_repository.dart
@@ -29,14 +29,14 @@ class ScheduleRepository {
   }
 
   Future updateSchedule(
-    final int id,
+    final int scheduleId,
     final String title,
     final bool isWholeDay,
     final DateTime startDateTime,
     final DateTime endDateTime,
     final String description,
   ) async {
-    final schedule = await _getSchedule(id);
+    final schedule = await _getSchedule(scheduleId);
     return _calendarDataStore.updateSchedule(
         schedule, title, isWholeDay, startDateTime, endDateTime, description);
   }

--- a/lib/data/repository/schedule_repository.dart
+++ b/lib/data/repository/schedule_repository.dart
@@ -13,6 +13,10 @@ class ScheduleRepository {
     return _calendarDataStore.getDayScheduleEntries(dateTime);
   }
 
+  Future<Schedule> getScheduleEntry(final int scheduleId) {
+    return _calendarDataStore.getScheduleEntry(scheduleId);
+  }
+
   Future addSchedule(
     final String title,
     final bool isWholeDay,
@@ -42,7 +46,7 @@ class ScheduleRepository {
     return _calendarDataStore.deleteSchedule(schedule);
   }
 
-  Future<Schedule> _getSchedule(final int id) {
-    return _calendarDataStore.getScheduleById(id);
+  Future<Schedule> _getSchedule(final int scheduleId) {
+    return _calendarDataStore.getScheduleEntry(scheduleId);
   }
 }

--- a/lib/domain/calculator/datetime_calculator.dart
+++ b/lib/domain/calculator/datetime_calculator.dart
@@ -1,0 +1,16 @@
+
+class DateTimeCalculator {
+  static DateTime getClampedStartDateTime(DateTime startDateTime, DateTime endDateTime) {
+    if (startDateTime.isAfter(endDateTime)) {
+      return startDateTime;
+    }
+    return endDateTime;
+  }
+
+  static DateTime getClampedEndDateTime(DateTime startDateTime, DateTime endDateTime) {
+    if (startDateTime.isBefore(endDateTime)) {
+      return endDateTime;
+    }
+    return startDateTime.add(const Duration(hours: 1));
+  }
+}

--- a/lib/domain/provider/calendar_providers.dart
+++ b/lib/domain/provider/calendar_providers.dart
@@ -1,6 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/data/repository/schedule_repository.dart';
 import 'package:schedule_management_app/domain/provider/repository_providers.dart';
+import 'package:schedule_management_app/domain/provider/schedule_list_providers.dart';
 import 'package:schedule_management_app/domain/provider/transition_providers.dart';
 import 'package:schedule_management_app/domain/use_case/calendar_use_case.dart';
 import 'package:schedule_management_app/presentation/presenter/calendar_presenter.dart';
@@ -17,7 +18,7 @@ final calendarUseCaseProvider = Provider(
   (ref) => CalendarUseCase(
     ref.watch(scheduleRepositoryProvider),
     ref.watch(calendarStateProvider.notifier),
-  )..refreshViewModel(),
+  )..reloadState(),
 );
 
 final calendarStateProvider = StateNotifierProvider<CalendarState, CalendarViewModel>(
@@ -37,6 +38,7 @@ final calendarStateProvider = StateNotifierProvider<CalendarState, CalendarViewM
 final calendarPresenterProvider = Provider(
   (ref) => CalendarPresenter(
     ref.watch(calendarUseCaseProvider),
+    ref.watch(scheduleListUseCaseProvider),
     ref.watch(transitionUseCaseProvider),
   ),
 );

--- a/lib/domain/provider/schedule_create_providers.dart
+++ b/lib/domain/provider/schedule_create_providers.dart
@@ -13,7 +13,7 @@ final scheduleCreateStateProvider =
     return ScheduleCreateState(
       ScheduleCreateViewModel(
         maximumYear: now.year + 100,
-        selectedDay: now,
+        selectedDateTime: now,
         title: '',
         isWholeDay: false,
         startDateTime: now,

--- a/lib/domain/provider/schedule_create_providers.dart
+++ b/lib/domain/provider/schedule_create_providers.dart
@@ -38,7 +38,6 @@ final scheduleCreateUseCaseProvider = Provider(
 
 final scheduleCreatePresenterProvider = Provider(
   (ref) => ScheduleCreatePresenter(
-    ref.watch(scheduleCreateStateProvider.notifier),
     ref.watch(scheduleCreateUseCaseProvider),
     ref.watch(calendarUseCaseProvider),
     ref.watch(scheduleListUseCaseProvider),

--- a/lib/domain/provider/schedule_create_providers.dart
+++ b/lib/domain/provider/schedule_create_providers.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/calendar_providers.dart';
+import 'package:schedule_management_app/domain/provider/schedule_list_providers.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_create_use_case.dart';
 import 'package:schedule_management_app/presentation/presenter/schedule_create_presenter.dart';
 import 'package:schedule_management_app/presentation/state/schedule_create_state.dart';
@@ -40,5 +41,6 @@ final scheduleCreatePresenterProvider = Provider(
     ref.watch(scheduleCreateStateProvider.notifier),
     ref.watch(scheduleCreateUseCaseProvider),
     ref.watch(calendarUseCaseProvider),
+    ref.watch(scheduleListUseCaseProvider),
   ),
 );

--- a/lib/domain/provider/schedule_edit_providers.dart
+++ b/lib/domain/provider/schedule_edit_providers.dart
@@ -1,0 +1,25 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:schedule_management_app/presentation/state/schedule_edit_state.dart';
+import 'package:schedule_management_app/presentation/view/view_model/schedule_edit_view_model.dart';
+
+final scheduleEditStateProvider =
+StateNotifierProvider<ScheduleEditState, ScheduleEditViewModel>(
+      (ref) {
+    final now = DateTime.now();
+
+    return ScheduleEditState(
+      ScheduleEditViewModel(
+        maximumYear: now.year + 100,
+        title: '',
+        isWholeDay: false,
+        startDateTime: now,
+        endDateTime: now,
+        startDateTimeText: '',
+        endDateTimeText: '',
+        description: '',
+        canSave: false,
+        isModified: false,
+      ),
+    );
+  },
+);

--- a/lib/domain/provider/schedule_edit_providers.dart
+++ b/lib/domain/provider/schedule_edit_providers.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/calendar_providers.dart';
+import 'package:schedule_management_app/domain/provider/schedule_list_providers.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_edit_use_case.dart';
 import 'package:schedule_management_app/presentation/presenter/schedule_edit_presenter.dart';
 import 'package:schedule_management_app/presentation/state/schedule_edit_state.dart';
@@ -38,5 +39,6 @@ final scheduleEditPresenterProvider = Provider(
   (ref) => ScheduleEditPresenter(
     ref.watch(scheduleEditUseCaseProvider),
     ref.watch(calendarUseCaseProvider),
+    ref.watch(scheduleListUseCaseProvider),
   ),
 );

--- a/lib/domain/provider/schedule_edit_providers.dart
+++ b/lib/domain/provider/schedule_edit_providers.dart
@@ -1,14 +1,17 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:schedule_management_app/domain/provider/calendar_providers.dart';
+import 'package:schedule_management_app/domain/use_case/schedule_edit_use_case.dart';
+import 'package:schedule_management_app/presentation/presenter/schedule_edit_presenter.dart';
 import 'package:schedule_management_app/presentation/state/schedule_edit_state.dart';
 import 'package:schedule_management_app/presentation/view/view_model/schedule_edit_view_model.dart';
 
-final scheduleEditStateProvider =
-StateNotifierProvider<ScheduleEditState, ScheduleEditViewModel>(
-      (ref) {
+final scheduleEditStateProvider = StateNotifierProvider<ScheduleEditState, ScheduleEditViewModel>(
+  (ref) {
     final now = DateTime.now();
 
     return ScheduleEditState(
       ScheduleEditViewModel(
+        scheduleId: 0,
         maximumYear: now.year + 100,
         title: '',
         isWholeDay: false,
@@ -22,4 +25,18 @@ StateNotifierProvider<ScheduleEditState, ScheduleEditViewModel>(
       ),
     );
   },
+);
+
+final scheduleEditUseCaseProvider = Provider(
+  (ref) => ScheduleEditUseCase(
+    ref.watch(scheduleRepositoryProvider),
+    ref.watch(scheduleEditStateProvider.notifier),
+  ),
+);
+
+final scheduleEditPresenterProvider = Provider(
+  (ref) => ScheduleEditPresenter(
+    ref.watch(scheduleEditUseCaseProvider),
+    ref.watch(calendarUseCaseProvider),
+  ),
 );

--- a/lib/domain/provider/schedule_list_providers.dart
+++ b/lib/domain/provider/schedule_list_providers.dart
@@ -8,7 +8,7 @@ import 'package:schedule_management_app/presentation/view/view_model/schedule_li
 final scheduleListStateProvider = StateNotifierProvider<ScheduleListState, ScheduleListViewModel>(
   (ref) => ScheduleListState(
     ScheduleListViewModel(
-      selectedDay: DateTime.now(),
+      selectedDateTime: DateTime.now(),
       scheduleElements: [],
     ),
   ),

--- a/lib/domain/provider/schedule_list_providers.dart
+++ b/lib/domain/provider/schedule_list_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:schedule_management_app/domain/provider/calendar_providers.dart';
 import 'package:schedule_management_app/domain/provider/transition_providers.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_list_use_case.dart';
 import 'package:schedule_management_app/presentation/presenter/schedule_list_presenter.dart';
@@ -19,7 +20,10 @@ final scheduleListStateProvider = StateNotifierProvider<ScheduleListState, Sched
 );
 
 final scheduleListUseCaseProvider = Provider(
-  (ref) => ScheduleListUseCase(),
+  (ref) => ScheduleListUseCase(
+    ref.watch(scheduleRepositoryProvider),
+    ref.watch(scheduleListStateProvider.notifier),
+  ),
 );
 
 final scheduleListPresenterProvider = Provider(

--- a/lib/domain/provider/schedule_list_providers.dart
+++ b/lib/domain/provider/schedule_list_providers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/transition_providers.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_list_use_case.dart';
@@ -9,6 +10,9 @@ final scheduleListStateProvider = StateNotifierProvider<ScheduleListState, Sched
   (ref) => ScheduleListState(
     ScheduleListViewModel(
       selectedDateTime: DateTime.now(),
+      selectedDateTimeText: '',
+      weekDayText: '',
+      weekDayColor: Colors.black,
       scheduleElements: [],
     ),
   ),

--- a/lib/domain/provider/transition_providers.dart
+++ b/lib/domain/provider/transition_providers.dart
@@ -1,6 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/calendar_providers.dart';
 import 'package:schedule_management_app/domain/provider/schedule_create_providers.dart';
+import 'package:schedule_management_app/domain/provider/schedule_edit_providers.dart';
 import 'package:schedule_management_app/domain/provider/schedule_list_providers.dart';
 import 'package:schedule_management_app/domain/use_case/transition_use_case.dart';
 
@@ -9,5 +10,6 @@ final transitionUseCaseProvider = Provider(
     ref.watch(scheduleRepositoryProvider),
     ref.watch(scheduleListStateProvider.notifier),
     ref.watch(scheduleCreateStateProvider.notifier),
+    ref.watch(scheduleEditStateProvider.notifier),
   ),
 );

--- a/lib/domain/provider/transition_providers.dart
+++ b/lib/domain/provider/transition_providers.dart
@@ -2,13 +2,11 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/calendar_providers.dart';
 import 'package:schedule_management_app/domain/provider/schedule_create_providers.dart';
 import 'package:schedule_management_app/domain/provider/schedule_edit_providers.dart';
-import 'package:schedule_management_app/domain/provider/schedule_list_providers.dart';
 import 'package:schedule_management_app/domain/use_case/transition_use_case.dart';
 
 final transitionUseCaseProvider = Provider(
   (ref) => TransitionUseCase(
     ref.watch(scheduleRepositoryProvider),
-    ref.watch(scheduleListStateProvider.notifier),
     ref.watch(scheduleCreateStateProvider.notifier),
     ref.watch(scheduleEditStateProvider.notifier),
   ),

--- a/lib/domain/use_case/calendar_use_case.dart
+++ b/lib/domain/use_case/calendar_use_case.dart
@@ -14,7 +14,7 @@ class CalendarUseCase {
 
   CalendarUseCase(final this._repository, final this._state);
 
-  Future reloadState() async {
+  Future<void> reloadState() async {
     _eventHashMap ??= LinkedHashMap<DateTime, List<String>>(
       equals: isSameDay,
       hashCode: _getHashCode,
@@ -33,7 +33,7 @@ class CalendarUseCase {
     return _repository.getMonthScheduleEntries(dateTime);
   }
 
-  Future updateMonthEntries() async {
+  Future<void> updateMonthEntries() async {
     final entries = await getMonthScheduleEntries(_focusedDateTime);
 
     final modelList = entries
@@ -62,7 +62,7 @@ class CalendarUseCase {
     _state.focusToday();
   }
 
-  Future focusMonth(final DateTime dateTime) async {
+  Future<void> focusMonth(final DateTime dateTime) async {
     _state.focusMonth(dateTime);
     await reloadState();
   }

--- a/lib/domain/use_case/calendar_use_case.dart
+++ b/lib/domain/use_case/calendar_use_case.dart
@@ -10,9 +10,7 @@ class CalendarUseCase {
   final CalendarState _state;
   LinkedHashMap<DateTime, List<String>>? _eventHashMap;
 
-  int get _focusedYear => _state.viewModel.focusedDay.year;
-
-  int get _focusedMonth => _state.viewModel.focusedDay.month;
+  DateTime get _focusedDateTime => _state.viewModel.focusedDay;
 
   CalendarUseCase(final this._repository, final this._state);
 
@@ -22,7 +20,7 @@ class CalendarUseCase {
       hashCode: _getHashCode,
     );
 
-    final entries = await _repository.getMonthScheduleEntries(_focusedYear, _focusedMonth);
+    final entries = await _repository.getMonthScheduleEntries(_focusedDateTime);
 
     final hashMap = LinkedHashMap.fromIterables(
         entries.map((entry) => entry.startDateTime), entries.map((entry) => [entry.title]));
@@ -31,12 +29,12 @@ class CalendarUseCase {
     await updateMonthEntries();
   }
 
-  Future<List<Schedule>> getMonthScheduleEntries(final int year, final int month) {
-    return _repository.getMonthScheduleEntries(year, month);
+  Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
+    return _repository.getMonthScheduleEntries(dateTime);
   }
 
   Future updateMonthEntries() async {
-    final entries = await getMonthScheduleEntries(_focusedYear, _focusedMonth);
+    final entries = await getMonthScheduleEntries(_focusedDateTime);
 
     final modelList = entries
         .map(

--- a/lib/domain/use_case/calendar_use_case.dart
+++ b/lib/domain/use_case/calendar_use_case.dart
@@ -14,7 +14,7 @@ class CalendarUseCase {
 
   CalendarUseCase(final this._repository, final this._state);
 
-  Future refreshViewModel() async {
+  Future reloadState() async {
     _eventHashMap ??= LinkedHashMap<DateTime, List<String>>(
       equals: isSameDay,
       hashCode: _getHashCode,
@@ -64,7 +64,7 @@ class CalendarUseCase {
 
   Future focusMonth(final DateTime dateTime) async {
     _state.focusMonth(dateTime);
-    await refreshViewModel();
+    await reloadState();
   }
 
   void setSelectedDay(final DateTime selectedDay) {

--- a/lib/domain/use_case/schedule_create_use_case.dart
+++ b/lib/domain/use_case/schedule_create_use_case.dart
@@ -36,8 +36,8 @@ class ScheduleCreateUseCase {
     ref.refresh(scheduleCreateStateProvider);
   }
 
-  Future<void> save() {
-    return _repository.addSchedule(
+  Future<void> save() async {
+    await _repository.addSchedule(
       _viewModel.title,
       _viewModel.isWholeDay,
       _viewModel.startDateTime,

--- a/lib/domain/use_case/schedule_create_use_case.dart
+++ b/lib/domain/use_case/schedule_create_use_case.dart
@@ -13,13 +13,6 @@ class ScheduleCreateUseCase {
 
   ScheduleCreateUseCase(final this._repository, final this._state);
 
-  VoidCallback? getSaveCallback() {
-    if (!_viewModel.canSave) {
-      return null;
-    }
-    return _save;
-  }
-
   void setTitle(final String title) {
     _state.setTitle(title);
   }
@@ -44,8 +37,8 @@ class ScheduleCreateUseCase {
     ref.refresh(scheduleCreateStateProvider);
   }
 
-  Future _save() async {
-    await _repository.addSchedule(
+  Future save() {
+    return _repository.addSchedule(
       _viewModel.title,
       _viewModel.isWholeDay,
       _viewModel.startDateTime,

--- a/lib/domain/use_case/schedule_create_use_case.dart
+++ b/lib/domain/use_case/schedule_create_use_case.dart
@@ -36,7 +36,7 @@ class ScheduleCreateUseCase {
     ref.refresh(scheduleCreateStateProvider);
   }
 
-  Future save() {
+  Future<void> save() {
     return _repository.addSchedule(
       _viewModel.title,
       _viewModel.isWholeDay,

--- a/lib/domain/use_case/schedule_create_use_case.dart
+++ b/lib/domain/use_case/schedule_create_use_case.dart
@@ -17,7 +17,7 @@ class ScheduleCreateUseCase {
   }
 
   void setStartDateTime(final DateTime startDateTime) {
-    _state.setEndDateTime(startDateTime);
+    _state.setStartDateTime(startDateTime);
   }
 
   void setEndDateTime(final DateTime endDateTime) {

--- a/lib/domain/use_case/schedule_create_use_case.dart
+++ b/lib/domain/use_case/schedule_create_use_case.dart
@@ -24,6 +24,14 @@ class ScheduleCreateUseCase {
     _state.setTitle(title);
   }
 
+  void setStartDateTime(final DateTime startDateTime) {
+    _state.setEndDateTime(startDateTime);
+  }
+
+  void setEndDateTime(final DateTime endDateTime) {
+    _state.setEndDateTime(endDateTime);
+  }
+
   void setDescription(final String description) {
     _state.setDescription(description);
   }

--- a/lib/domain/use_case/schedule_edit_use_case.dart
+++ b/lib/domain/use_case/schedule_edit_use_case.dart
@@ -21,7 +21,7 @@ class ScheduleEditUseCase {
   }
 
   void setStartDateTime(final DateTime startDateTime) {
-    _state.setEndDateTime(startDateTime);
+    _state.setStartDateTime(startDateTime);
   }
 
   void setEndDateTime(final DateTime endDateTime) {

--- a/lib/domain/use_case/schedule_edit_use_case.dart
+++ b/lib/domain/use_case/schedule_edit_use_case.dart
@@ -32,8 +32,8 @@ class ScheduleEditUseCase {
     _state.setDescription(description);
   }
 
-  Future<void> save() {
-    return _repository.updateSchedule(
+  Future<void> save() async {
+    await _repository.updateSchedule(
       _viewModel.scheduleId,
       _viewModel.title,
       _viewModel.isWholeDay,

--- a/lib/domain/use_case/schedule_edit_use_case.dart
+++ b/lib/domain/use_case/schedule_edit_use_case.dart
@@ -32,7 +32,7 @@ class ScheduleEditUseCase {
     _state.setDescription(description);
   }
 
-  Future save() {
+  Future<void> save() {
     return _repository.updateSchedule(
       _viewModel.scheduleId,
       _viewModel.title,

--- a/lib/domain/use_case/schedule_edit_use_case.dart
+++ b/lib/domain/use_case/schedule_edit_use_case.dart
@@ -1,19 +1,23 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/data/repository/schedule_repository.dart';
-import 'package:schedule_management_app/domain/provider/schedule_create_providers.dart';
-import 'package:schedule_management_app/presentation/state/schedule_create_state.dart';
-import 'package:schedule_management_app/presentation/view/view_model/schedule_create_view_model.dart';
+import 'package:schedule_management_app/domain/provider/schedule_edit_providers.dart';
+import 'package:schedule_management_app/presentation/state/schedule_edit_state.dart';
+import 'package:schedule_management_app/presentation/view/view_model/schedule_edit_view_model.dart';
 
-class ScheduleCreateUseCase {
+class ScheduleEditUseCase {
   final ScheduleRepository _repository;
-  final ScheduleCreateState _state;
+  final ScheduleEditState _state;
 
-  ScheduleCreateViewModel get _viewModel => _state.viewModel;
+  ScheduleEditViewModel get _viewModel => _state.viewModel;
 
-  ScheduleCreateUseCase(final this._repository, final this._state);
+  ScheduleEditUseCase(final this._repository, final this._state);
 
   void setTitle(final String title) {
     _state.setTitle(title);
+  }
+
+  void setWholeDay(final bool isWholeDay) {
+    _state.setWholeDay(isWholeDay);
   }
 
   void setStartDateTime(final DateTime startDateTime) {
@@ -28,21 +32,18 @@ class ScheduleCreateUseCase {
     _state.setDescription(description);
   }
 
-  void setWholeDay(final bool isWholeDay) {
-    _state.setWholeDay(isWholeDay);
-  }
-
-  void refreshState(final WidgetRef ref) {
-    ref.refresh(scheduleCreateStateProvider);
-  }
-
   Future save() {
-    return _repository.addSchedule(
+    return _repository.updateSchedule(
+      _viewModel.scheduleId,
       _viewModel.title,
       _viewModel.isWholeDay,
       _viewModel.startDateTime,
       _viewModel.endDateTime,
       _viewModel.description,
     );
+  }
+
+  void refreshState(final WidgetRef ref) {
+    ref.refresh(scheduleEditStateProvider);
   }
 }

--- a/lib/domain/use_case/schedule_list_use_case.dart
+++ b/lib/domain/use_case/schedule_list_use_case.dart
@@ -18,7 +18,7 @@ class ScheduleListUseCase {
     _state.setSelectedDay(selectedDateTime);
   }
 
-  Future reloadState() async {
+  Future<void> reloadState() async {
     final selectedDateTime = _state.viewModel.selectedDateTime;
     final entries = await _repository.getDayScheduleEntries(selectedDateTime);
 

--- a/lib/domain/use_case/schedule_list_use_case.dart
+++ b/lib/domain/use_case/schedule_list_use_case.dart
@@ -1,3 +1,48 @@
-// TODO スケジュール編集処理
+import 'package:intl/intl.dart';
+import 'package:schedule_management_app/data/repository/schedule_repository.dart';
+import 'package:schedule_management_app/presentation/state/schedule_list_state.dart';
+import 'package:schedule_management_app/presentation/view/constants/schedule_list_constants.dart';
+import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
+import 'package:schedule_management_app/presentation/view/view_model/schedule_list_element_model.dart';
+
 class ScheduleListUseCase {
+  final ScheduleRepository _repository;
+  final ScheduleListState _state;
+
+  ScheduleListUseCase(
+    final this._repository,
+    final this._state,
+  );
+
+  void setSelectedDay(DateTime selectedDateTime) {
+    _state.setSelectedDay(selectedDateTime);
+  }
+
+  Future reloadState() async {
+    final selectedDateTime = _state.viewModel.selectedDateTime;
+    final entries = await _repository.getDayScheduleEntries(selectedDateTime);
+
+    final scheduleElements = entries
+        .map((entry) => ScheduleListElementModel(
+              scheduleId: entry.id,
+              isWholeDay: entry.isWholeDay,
+              startDateTime: entry.startDateTime,
+              endDateTime: entry.endDateTime,
+              dateTimeTexts: entry.isWholeDay
+                  ? [TextConstants.scheduleListViewWholeDay]
+                  : [
+                      _getDateTimeText().format(entry.startDateTime),
+                      _getDateTimeText().format(entry.endDateTime),
+                    ],
+              scheduleTitle: entry.title,
+            ))
+        .toList();
+
+    _state.setScheduleElements(scheduleElements);
+  }
+
+  DateFormat _getDateTimeText() => DateFormat(
+        TextConstants.scheduleListViewTimeFormat,
+        ScheduleListConstants.scheduleListLocale,
+      );
 }

--- a/lib/domain/use_case/transition_use_case.dart
+++ b/lib/domain/use_case/transition_use_case.dart
@@ -20,14 +20,9 @@ class TransitionUseCase {
     final this._scheduleCreateState,
   );
 
-  Future showScheduleListView(final BuildContext context, final DateTime selectedDay) async {
-    _scheduleListState.setSelectedDay(selectedDay);
-
-    await _refreshScheduleListState(
-      selectedDay.year,
-      selectedDay.month,
-      selectedDay.day,
-    );
+  Future showScheduleListView(final BuildContext context, final DateTime selectedDateTime) async {
+    _scheduleListState.setSelectedDay(selectedDateTime);
+    await _refreshScheduleListState(selectedDateTime);
 
     return showDialog(
       context: context,
@@ -55,8 +50,8 @@ class TransitionUseCase {
     );
   }
 
-  Future _refreshScheduleListState(final int year, final int month, final int day) async {
-    final entries = await _repository.getDayScheduleEntries(year, month, day);
+  Future _refreshScheduleListState(final DateTime dateTime) async {
+    final entries = await _repository.getDayScheduleEntries(dateTime);
 
     final scheduleElements = entries
         .map((entry) => ScheduleListElementModel(

--- a/lib/domain/use_case/transition_use_case.dart
+++ b/lib/domain/use_case/transition_use_case.dart
@@ -1,38 +1,26 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:schedule_management_app/data/repository/schedule_repository.dart';
 import 'package:schedule_management_app/presentation/state/schedule_create_state.dart';
 import 'package:schedule_management_app/presentation/state/schedule_edit_state.dart';
-import 'package:schedule_management_app/presentation/state/schedule_list_state.dart';
-import 'package:schedule_management_app/presentation/view/constants/schedule_list_constants.dart';
-import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
 import 'package:schedule_management_app/presentation/view/view/schedule_create_view.dart';
 import 'package:schedule_management_app/presentation/view/view/schedule_edit_view.dart';
 import 'package:schedule_management_app/presentation/view/view/schedule_list_view.dart';
-import 'package:schedule_management_app/presentation/view/view_model/schedule_list_element_model.dart';
 
 class TransitionUseCase {
   final ScheduleRepository _repository;
-  final ScheduleListState _scheduleListState;
   final ScheduleCreateState _scheduleCreateState;
   final ScheduleEditState _scheduleEditState;
 
   TransitionUseCase(
     final this._repository,
-    final this._scheduleListState,
     final this._scheduleCreateState,
     final this._scheduleEditState,
   );
 
-  Future showScheduleListView(final BuildContext context, final DateTime selectedDateTime) async {
-    _scheduleListState.setSelectedDay(selectedDateTime);
-    await _refreshScheduleListState(selectedDateTime);
-
+  Future showScheduleListView(final BuildContext context) async {
     return showDialog(
       context: context,
-      builder: (builder) {
-        return const ScheduleListView();
-      },
+      builder: (_) => const ScheduleListView(),
     );
   }
 
@@ -41,12 +29,8 @@ class TransitionUseCase {
 
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (BuildContext context) {
-          return const ScheduleCreateView();
-        },
+        builder: (_) => const ScheduleCreateView(),
       ),
-    ).then(
-      (value) async => await _refreshScheduleListState(selectedDateTime),
     );
   }
 
@@ -64,39 +48,8 @@ class TransitionUseCase {
 
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (BuildContext context) {
-          return const ScheduleEditView();
-        },
+        builder: (_) => const ScheduleEditView(),
       ),
-    ).then(
-      (value) async => await _refreshScheduleListState(selectedDateTime),
     );
   }
-
-  Future _refreshScheduleListState(final DateTime dateTime) async {
-    final entries = await _repository.getDayScheduleEntries(dateTime);
-
-    final scheduleElements = entries
-        .map((entry) => ScheduleListElementModel(
-              scheduleId: entry.id,
-              isWholeDay: entry.isWholeDay,
-              startDateTime: entry.startDateTime,
-              endDateTime: entry.endDateTime,
-              dateTimeTexts: entry.isWholeDay
-                  ? [TextConstants.scheduleListViewWholeDay]
-                  : [
-                      _getDateTimeText().format(entry.startDateTime),
-                      _getDateTimeText().format(entry.endDateTime),
-                    ],
-              scheduleTitle: entry.title,
-            ))
-        .toList();
-
-    _scheduleListState.setScheduleElements(scheduleElements);
-  }
-
-  DateFormat _getDateTimeText() => DateFormat(
-        TextConstants.scheduleListViewTimeFormat,
-        ScheduleListConstants.scheduleListLocale,
-      );
 }

--- a/lib/domain/use_case/transition_use_case.dart
+++ b/lib/domain/use_case/transition_use_case.dart
@@ -17,7 +17,7 @@ class TransitionUseCase {
     final this._scheduleEditState,
   );
 
-  Future showScheduleListView(final BuildContext context) async {
+  Future<void> showScheduleListView(final BuildContext context) async {
     return showDialog(
       context: context,
       builder: (_) => const ScheduleListView(),

--- a/lib/domain/use_case/transition_use_case.dart
+++ b/lib/domain/use_case/transition_use_case.dart
@@ -28,18 +28,12 @@ class TransitionUseCase {
       context: context,
       builder: (builder) {
         return const ScheduleListView();
-      },// TODO 予定一覧画面を閉じたときにカレンダーを更新する
-    );/*.then(
-      (value) async => await _refreshScheduleListState(
-        selectedDay.year,
-        selectedDay.month,
-        selectedDay.day,
-      ),
-    );*/
+      },
+    );
   }
 
-  void showScheduleCreateView(final BuildContext context, final DateTime selectedDay) {
-    _scheduleCreateState.setSelectedDay(selectedDay);
+  void showScheduleCreateView(final BuildContext context, final DateTime selectedDateTime) {
+    _scheduleCreateState.setSelectedDay(selectedDateTime);
 
     Navigator.of(context).push(
       MaterialPageRoute(
@@ -47,6 +41,8 @@ class TransitionUseCase {
           return const ScheduleCreateView();
         },
       ),
+    ).then(
+          (value) async => await _refreshScheduleListState(selectedDateTime),
     );
   }
 

--- a/lib/domain/use_case/transition_use_case.dart
+++ b/lib/domain/use_case/transition_use_case.dart
@@ -34,7 +34,11 @@ class TransitionUseCase {
     );
   }
 
-  void showScheduleEditView(final BuildContext context, final int scheduleId, final DateTime selectedDateTime) async {
+  Future<void> showScheduleEditView(
+    final BuildContext context,
+    final int scheduleId,
+    final DateTime selectedDateTime,
+  ) async {
     final schedule = await _repository.getScheduleEntry(scheduleId);
 
     _scheduleEditState.set(

--- a/lib/domain/use_case/transition_use_case.dart
+++ b/lib/domain/use_case/transition_use_case.dart
@@ -50,10 +50,11 @@ class TransitionUseCase {
     );
   }
 
-  void showScheduleEditView(final BuildContext context, final int scheduleId) async {
+  void showScheduleEditView(final BuildContext context, final int scheduleId, final DateTime selectedDateTime) async {
     final schedule = await _repository.getScheduleEntry(scheduleId);
 
     _scheduleEditState.set(
+      schedule.id,
       schedule.title,
       schedule.isWholeDay,
       schedule.startDateTime,
@@ -67,6 +68,8 @@ class TransitionUseCase {
           return const ScheduleEditView();
         },
       ),
+    ).then(
+      (value) async => await _refreshScheduleListState(selectedDateTime),
     );
   }
 

--- a/lib/domain/use_case/transition_use_case.dart
+++ b/lib/domain/use_case/transition_use_case.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:schedule_management_app/data/repository/schedule_repository.dart';
 import 'package:schedule_management_app/presentation/state/schedule_create_state.dart';
+import 'package:schedule_management_app/presentation/state/schedule_edit_state.dart';
 import 'package:schedule_management_app/presentation/state/schedule_list_state.dart';
 import 'package:schedule_management_app/presentation/view/constants/schedule_list_constants.dart';
 import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
 import 'package:schedule_management_app/presentation/view/view/schedule_create_view.dart';
+import 'package:schedule_management_app/presentation/view/view/schedule_edit_view.dart';
 import 'package:schedule_management_app/presentation/view/view/schedule_list_view.dart';
 import 'package:schedule_management_app/presentation/view/view_model/schedule_list_element_model.dart';
 
@@ -13,11 +15,13 @@ class TransitionUseCase {
   final ScheduleRepository _repository;
   final ScheduleListState _scheduleListState;
   final ScheduleCreateState _scheduleCreateState;
+  final ScheduleEditState _scheduleEditState;
 
   TransitionUseCase(
     final this._repository,
     final this._scheduleListState,
     final this._scheduleCreateState,
+    final this._scheduleEditState,
   );
 
   Future showScheduleListView(final BuildContext context, final DateTime selectedDateTime) async {
@@ -42,7 +46,27 @@ class TransitionUseCase {
         },
       ),
     ).then(
-          (value) async => await _refreshScheduleListState(selectedDateTime),
+      (value) async => await _refreshScheduleListState(selectedDateTime),
+    );
+  }
+
+  void showScheduleEditView(final BuildContext context, final int scheduleId) async {
+    final schedule = await _repository.getScheduleEntry(scheduleId);
+
+    _scheduleEditState.set(
+      schedule.title,
+      schedule.isWholeDay,
+      schedule.startDateTime,
+      schedule.endDateTime,
+      schedule.description,
+    );
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (BuildContext context) {
+          return const ScheduleEditView();
+        },
+      ),
     );
   }
 
@@ -51,6 +75,7 @@ class TransitionUseCase {
 
     final scheduleElements = entries
         .map((entry) => ScheduleListElementModel(
+              scheduleId: entry.id,
               isWholeDay: entry.isWholeDay,
               startDateTime: entry.startDateTime,
               endDateTime: entry.endDateTime,

--- a/lib/presentation/presenter/calendar_presenter.dart
+++ b/lib/presentation/presenter/calendar_presenter.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:schedule_management_app/domain/use_case/calendar_use_case.dart';
+import 'package:schedule_management_app/domain/use_case/schedule_list_use_case.dart';
 import 'package:schedule_management_app/domain/use_case/transition_use_case.dart';
 
 class CalendarPresenter {
   final CalendarUseCase _useCase;
+  final ScheduleListUseCase _scheduleListUseCase;
   final TransitionUseCase _transitionUseCase;
 
   CalendarPresenter(
     final this._useCase,
+    final this._scheduleListUseCase,
     final this._transitionUseCase,
   );
 
@@ -28,6 +31,8 @@ class CalendarPresenter {
 
   Future showScheduleListView(final BuildContext context, final DateTime selectedDay) async {
     _useCase.setSelectedDay(selectedDay);
-    return await _transitionUseCase.showScheduleListView(context, selectedDay);
+    _scheduleListUseCase.setSelectedDay(selectedDay);
+    await _scheduleListUseCase.reloadState();
+    return await _transitionUseCase.showScheduleListView(context);
   }
 }

--- a/lib/presentation/presenter/calendar_presenter.dart
+++ b/lib/presentation/presenter/calendar_presenter.dart
@@ -22,14 +22,14 @@ class CalendarPresenter {
     _useCase.focusToday();
   }
 
-  Future focusMonth(final DateTime? dateTime) async {
+  Future<void> focusMonth(final DateTime? dateTime) async {
     if (dateTime == null) {
       return;
     }
     await _useCase.focusMonth(dateTime);
   }
 
-  Future showScheduleListView(final BuildContext context, final DateTime selectedDay) async {
+  Future<void> showScheduleListView(final BuildContext context, final DateTime selectedDay) async {
     _useCase.setSelectedDay(selectedDay);
     _scheduleListUseCase.setSelectedDay(selectedDay);
     await _scheduleListUseCase.reloadState();

--- a/lib/presentation/presenter/schedule_create_presenter.dart
+++ b/lib/presentation/presenter/schedule_create_presenter.dart
@@ -34,11 +34,11 @@ class ScheduleCreatePresenter {
     _useCase.setWholeDay(isWholeDay);
   }
 
-  void save(final WidgetRef ref) async {
+  Future<void> save(final WidgetRef ref) async {
     await _useCase.save();
-    _calendarUseCase.reloadState();
+    await _calendarUseCase.reloadState();
     _useCase.refreshState(ref);
-    _scheduleListUseCase.reloadState();
+    await _scheduleListUseCase.reloadState();
   }
 
   void refreshState(final WidgetRef ref) {

--- a/lib/presentation/presenter/schedule_create_presenter.dart
+++ b/lib/presentation/presenter/schedule_create_presenter.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/use_case/calendar_use_case.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_create_use_case.dart';
 import 'package:schedule_management_app/presentation/state/schedule_create_state.dart';
-import 'package:schedule_management_app/presentation/view/constants/schedule_create_constants.dart';
 import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
-import 'package:schedule_management_app/presentation/view/view_model/schedule_create_view_model.dart';
 
 class ScheduleCreatePresenter {
   final ScheduleCreateState _state;
@@ -32,34 +29,20 @@ class ScheduleCreatePresenter {
     _useCase.setTitle(title);
   }
 
+  void setStartDateTime(final DateTime startDateTime) {
+    _useCase.setStartDateTime(startDateTime);
+  }
+
+  void setEndDateTime(final DateTime endDateTime) {
+    _useCase.setEndDateTime(endDateTime);
+  }
+
   void setDescription(final String description) {
     _useCase.setDescription(description);
   }
 
   void setWholeDay(final bool isWholeDay) {
     _useCase.setWholeDay(isWholeDay);
-  }
-
-  void showStartDateTimePicker(final BuildContext context) {
-    _showDateTimePicker(
-      context,
-      _state.viewModel,
-      _state.viewModel.startDateTime,
-      (dateTime) {
-        _state.setStartDateTime(dateTime);
-      },
-    );
-  }
-
-  void showEndDateTimePicker(final BuildContext context) {
-    _showDateTimePicker(
-      context,
-      _state.viewModel,
-      _state.viewModel.endDateTime,
-      (dateTime) {
-        _state.setEndDateTime(dateTime);
-      },
-    );
   }
 
   void closeView(final BuildContext context, final WidgetRef ref) {
@@ -73,42 +56,6 @@ class ScheduleCreatePresenter {
   void _popAndRefreshState(final BuildContext context, final WidgetRef ref) {
     Navigator.pop(context);
     _useCase.refreshState(ref);
-  }
-
-  void _showDateTimePicker(
-    final BuildContext context,
-    final ScheduleCreateViewModel viewModel,
-    final DateTime initialDateTime,
-    final ValueChanged<DateTime> onDateTimeChanged,
-  ) {
-    showCupertinoModalPopup(
-      context: context,
-      builder: (context) {
-        return Container(
-          height: 300.0,
-          color: Colors.white,
-          child: Column(
-            children: [
-              SizedBox(
-                height: 300.0,
-                child: CupertinoDatePicker(
-                  minuteInterval: 15,
-                  use24hFormat: true,
-                  mode: viewModel.isWholeDay
-                      ? CupertinoDatePickerMode.date
-                      : CupertinoDatePickerMode.dateAndTime,
-                  dateOrder: DatePickerDateOrder.ymd,
-                  minimumYear: ScheduleCreateConstants.minimumYear,
-                  maximumYear: viewModel.maximumYear,
-                  initialDateTime: initialDateTime,
-                  onDateTimeChanged: onDateTimeChanged,
-                ),
-              )
-            ],
-          ),
-        );
-      },
-    );
   }
 
   Future<dynamic> _showModifiedPopup(final BuildContext context, final WidgetRef ref) {

--- a/lib/presentation/presenter/schedule_create_presenter.dart
+++ b/lib/presentation/presenter/schedule_create_presenter.dart
@@ -10,20 +10,7 @@ class ScheduleCreatePresenter {
   final ScheduleCreateUseCase _useCase;
   final CalendarUseCase _calendarUseCase;
 
-  ScheduleCreatePresenter(final this._state, final this._useCase,final this._calendarUseCase);
-
-  VoidCallback? getSaveCallback(final BuildContext context, final WidgetRef ref) {
-    final callback = _useCase.getSaveCallback();
-    if (callback == null) {
-      return null;
-    }
-
-    return () async {
-      callback();
-      await _calendarUseCase.refreshViewModel();
-      _popAndRefreshState(context, ref);
-    };
-  }
+  ScheduleCreatePresenter(final this._state, final this._useCase, final this._calendarUseCase);
 
   void setTitle(final String title) {
     _useCase.setTitle(title);
@@ -51,6 +38,12 @@ class ScheduleCreatePresenter {
     } else {
       _popAndRefreshState(context, ref);
     }
+  }
+
+  void save(final WidgetRef ref) async {
+    await _useCase.save();
+    _calendarUseCase.refreshViewModel();
+    _useCase.refreshState(ref);
   }
 
   void _popAndRefreshState(final BuildContext context, final WidgetRef ref) {

--- a/lib/presentation/presenter/schedule_create_presenter.dart
+++ b/lib/presentation/presenter/schedule_create_presenter.dart
@@ -1,19 +1,14 @@
-import 'package:flutter/cupertino.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/use_case/calendar_use_case.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_create_use_case.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_list_use_case.dart';
-import 'package:schedule_management_app/presentation/state/schedule_create_state.dart';
-import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
 
 class ScheduleCreatePresenter {
-  final ScheduleCreateState _state;
   final ScheduleCreateUseCase _useCase;
   final CalendarUseCase _calendarUseCase;
   final ScheduleListUseCase _scheduleListUseCase;
 
   ScheduleCreatePresenter(
-    final this._state,
     final this._useCase,
     final this._calendarUseCase,
     final this._scheduleListUseCase,
@@ -39,14 +34,6 @@ class ScheduleCreatePresenter {
     _useCase.setWholeDay(isWholeDay);
   }
 
-  void closeView(final BuildContext context, final WidgetRef ref) {
-    if (_state.viewModel.isModified) {
-      _showModifiedPopup(context, ref);
-    } else {
-      _popAndRefreshState(context, ref);
-    }
-  }
-
   void save(final WidgetRef ref) async {
     await _useCase.save();
     _calendarUseCase.reloadState();
@@ -54,35 +41,7 @@ class ScheduleCreatePresenter {
     _scheduleListUseCase.reloadState();
   }
 
-  void _popAndRefreshState(final BuildContext context, final WidgetRef ref) {
-    Navigator.pop(context);
+  void refreshState(final WidgetRef ref) {
     _useCase.refreshState(ref);
-  }
-
-  Future<dynamic> _showModifiedPopup(final BuildContext context, final WidgetRef ref) {
-    return showCupertinoModalPopup(
-      context: context,
-      builder: (BuildContext context) {
-        return CupertinoActionSheet(
-          actions: [
-            CupertinoActionSheetAction(
-              onPressed: () {
-                // TODO 2回ポップするもっと良い方法を調べる
-                Navigator.of(context).pop();
-                Navigator.of(context).pop();
-                _useCase.refreshState(ref);
-              },
-              child: const Text(TextConstants.scheduleCreateViewActionSheetDiscardChanges),
-            ),
-            CupertinoActionSheetAction(
-              onPressed: () {
-                Navigator.pop(context);
-              },
-              child: const Text(TextConstants.scheduleCreateViewActionSheetCancel),
-            ),
-          ],
-        );
-      },
-    );
   }
 }

--- a/lib/presentation/presenter/schedule_create_presenter.dart
+++ b/lib/presentation/presenter/schedule_create_presenter.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/use_case/calendar_use_case.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_create_use_case.dart';
+import 'package:schedule_management_app/domain/use_case/schedule_list_use_case.dart';
 import 'package:schedule_management_app/presentation/state/schedule_create_state.dart';
 import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
 
@@ -9,8 +10,14 @@ class ScheduleCreatePresenter {
   final ScheduleCreateState _state;
   final ScheduleCreateUseCase _useCase;
   final CalendarUseCase _calendarUseCase;
+  final ScheduleListUseCase _scheduleListUseCase;
 
-  ScheduleCreatePresenter(final this._state, final this._useCase, final this._calendarUseCase);
+  ScheduleCreatePresenter(
+    final this._state,
+    final this._useCase,
+    final this._calendarUseCase,
+    final this._scheduleListUseCase,
+  );
 
   void setTitle(final String title) {
     _useCase.setTitle(title);
@@ -42,8 +49,9 @@ class ScheduleCreatePresenter {
 
   void save(final WidgetRef ref) async {
     await _useCase.save();
-    _calendarUseCase.refreshViewModel();
+    _calendarUseCase.reloadState();
     _useCase.refreshState(ref);
+    _scheduleListUseCase.reloadState();
   }
 
   void _popAndRefreshState(final BuildContext context, final WidgetRef ref) {

--- a/lib/presentation/presenter/schedule_edit_presenter.dart
+++ b/lib/presentation/presenter/schedule_edit_presenter.dart
@@ -1,12 +1,18 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/use_case/calendar_use_case.dart';
 import 'package:schedule_management_app/domain/use_case/schedule_edit_use_case.dart';
+import 'package:schedule_management_app/domain/use_case/schedule_list_use_case.dart';
 
 class ScheduleEditPresenter {
   final ScheduleEditUseCase _useCase;
   final CalendarUseCase _calendarUseCase;
+  final ScheduleListUseCase _scheduleListUseCase;
 
-  ScheduleEditPresenter(final this._useCase, final this._calendarUseCase);
+  ScheduleEditPresenter(
+    final this._useCase,
+    final this._calendarUseCase,
+    final this._scheduleListUseCase,
+  );
 
   void setTitle(final String title) {
     _useCase.setTitle(title);
@@ -28,9 +34,9 @@ class ScheduleEditPresenter {
     _useCase.setDescription(description);
   }
 
-  void save(final WidgetRef ref) async {
+  Future<void> save(final WidgetRef ref) async {
     await _useCase.save();
-    _calendarUseCase.refreshViewModel();
-    _useCase.refreshState(ref);
+    await _scheduleListUseCase.reloadState();
+    await _calendarUseCase.reloadState();
   }
 }

--- a/lib/presentation/presenter/schedule_edit_presenter.dart
+++ b/lib/presentation/presenter/schedule_edit_presenter.dart
@@ -1,0 +1,36 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:schedule_management_app/domain/use_case/calendar_use_case.dart';
+import 'package:schedule_management_app/domain/use_case/schedule_edit_use_case.dart';
+
+class ScheduleEditPresenter {
+  final ScheduleEditUseCase _useCase;
+  final CalendarUseCase _calendarUseCase;
+
+  ScheduleEditPresenter(final this._useCase, final this._calendarUseCase);
+
+  void setTitle(final String title) {
+    _useCase.setTitle(title);
+  }
+
+  void setWholeDay(final bool isWholeDay) {
+    _useCase.setWholeDay(isWholeDay);
+  }
+
+  void setStartDateTime(final DateTime startDateTime) {
+    _useCase.setStartDateTime(startDateTime);
+  }
+
+  void setEndDateTime(final DateTime endDateTime) {
+    _useCase.setEndDateTime(endDateTime);
+  }
+
+  void setDescription(final String description) {
+    _useCase.setDescription(description);
+  }
+
+  void save(final WidgetRef ref) async {
+    await _useCase.save();
+    _calendarUseCase.refreshViewModel();
+    _useCase.refreshState(ref);
+  }
+}

--- a/lib/presentation/presenter/schedule_edit_presenter.dart
+++ b/lib/presentation/presenter/schedule_edit_presenter.dart
@@ -39,4 +39,8 @@ class ScheduleEditPresenter {
     await _scheduleListUseCase.reloadState();
     await _calendarUseCase.reloadState();
   }
+
+  void refreshState(final WidgetRef ref) {
+    _useCase.refreshState(ref);
+  }
 }

--- a/lib/presentation/presenter/schedule_list_presenter.dart
+++ b/lib/presentation/presenter/schedule_list_presenter.dart
@@ -10,7 +10,11 @@ class ScheduleListPresenter {
     _transitionUseCase.showScheduleCreateView(context, selectedDateTime);
   }
 
-  void showScheduleEditView(final BuildContext context, final int scheduleId, final DateTime selectedDateTime) {
-    _transitionUseCase.showScheduleEditView(context, scheduleId, selectedDateTime);
+  Future<void> showScheduleEditView(
+    final BuildContext context,
+    final int scheduleId,
+    final DateTime selectedDateTime,
+  ) async {
+    await _transitionUseCase.showScheduleEditView(context, scheduleId, selectedDateTime);
   }
 }

--- a/lib/presentation/presenter/schedule_list_presenter.dart
+++ b/lib/presentation/presenter/schedule_list_presenter.dart
@@ -9,4 +9,8 @@ class ScheduleListPresenter {
   void showScheduleCreateView(final BuildContext context, final DateTime selectedDateTime) {
     _transitionUseCase.showScheduleCreateView(context, selectedDateTime);
   }
+
+  void showScheduleEditView(final BuildContext context, final int scheduleId) {
+    _transitionUseCase.showScheduleEditView(context, scheduleId);
+  }
 }

--- a/lib/presentation/presenter/schedule_list_presenter.dart
+++ b/lib/presentation/presenter/schedule_list_presenter.dart
@@ -6,7 +6,7 @@ class ScheduleListPresenter {
 
   ScheduleListPresenter(final this._transitionUseCase);
 
-  void showScheduleCreateView(BuildContext context, DateTime selectedDay) {
-    _transitionUseCase.showScheduleCreateView(context, selectedDay);
+  void showScheduleCreateView(final BuildContext context, final DateTime selectedDateTime) {
+    _transitionUseCase.showScheduleCreateView(context, selectedDateTime);
   }
 }

--- a/lib/presentation/presenter/schedule_list_presenter.dart
+++ b/lib/presentation/presenter/schedule_list_presenter.dart
@@ -10,7 +10,7 @@ class ScheduleListPresenter {
     _transitionUseCase.showScheduleCreateView(context, selectedDateTime);
   }
 
-  void showScheduleEditView(final BuildContext context, final int scheduleId) {
-    _transitionUseCase.showScheduleEditView(context, scheduleId);
+  void showScheduleEditView(final BuildContext context, final int scheduleId, final DateTime selectedDateTime) {
+    _transitionUseCase.showScheduleEditView(context, scheduleId, selectedDateTime);
   }
 }

--- a/lib/presentation/state/schedule_create_state.dart
+++ b/lib/presentation/state/schedule_create_state.dart
@@ -6,8 +6,6 @@ import 'package:schedule_management_app/presentation/view/view_model/schedule_cr
 class ScheduleCreateState extends StateNotifier<ScheduleCreateViewModel> {
   ScheduleCreateState(final ScheduleCreateViewModel state) : super(state);
 
-  ScheduleCreateState.init({required final ScheduleCreateViewModel state}) : super(state);
-
   ScheduleCreateViewModel get viewModel => state;
 
   void setSelectedDay(final DateTime dateTime) {
@@ -47,18 +45,18 @@ class ScheduleCreateState extends StateNotifier<ScheduleCreateViewModel> {
     );
   }
 
-  void setStartDateTime(final DateTime startDateTimeUtc) {
-    final dateTimeText = _getDateTimeText(startDateTimeUtc.toLocal(), state.isWholeDay);
+  void setStartDateTime(final DateTime startDateTime) {
+    final dateTimeText = _getDateTimeText(startDateTime.toLocal(), state.isWholeDay);
 
-    if (startDateTimeUtc.isBefore(state.endDateTime)) {
-      state = state.copyWith(startDateTime: startDateTimeUtc, startDateTimeText: dateTimeText);
+    if (startDateTime.isBefore(state.endDateTime)) {
+      state = state.copyWith(startDateTime: startDateTime, startDateTimeText: dateTimeText);
       return;
     }
 
-    final endTime = state.isWholeDay ? startDateTimeUtc : startDateTimeUtc.add(const Duration(hours: 1));
+    final endTime = state.isWholeDay ? startDateTime : startDateTime.add(const Duration(hours: 1));
 
     state = state.copyWith(
-      startDateTime: startDateTimeUtc,
+      startDateTime: startDateTime,
       startDateTimeText: dateTimeText,
       endDateTime: endTime,
       endDateTimeText: _getDateTimeText(endTime, state.isWholeDay),

--- a/lib/presentation/state/schedule_create_state.dart
+++ b/lib/presentation/state/schedule_create_state.dart
@@ -25,7 +25,7 @@ class ScheduleCreateState extends StateNotifier<ScheduleCreateViewModel> {
     final endDateTime = startDateTime;
 
     state = state.copyWith(
-      selectedDay: startDateTime,
+      selectedDateTime: startDateTime,
       startDateTime: startDateTime,
       endDateTime: endDateTime,
       startDateTimeText: _getDateTimeText(startDateTime, state.isWholeDay),
@@ -47,27 +47,28 @@ class ScheduleCreateState extends StateNotifier<ScheduleCreateViewModel> {
     );
   }
 
-  void setStartDateTime(final DateTime dateTime) {
-    final dateTimeText = _getDateTimeText(dateTime, state.isWholeDay);
+  void setStartDateTime(final DateTime startDateTimeUtc) {
+    final dateTimeText = _getDateTimeText(startDateTimeUtc.toLocal(), state.isWholeDay);
 
-    if (dateTime.isBefore(state.endDateTime)) {
-      state = state.copyWith(startDateTime: dateTime, startDateTimeText: dateTimeText);
+    if (startDateTimeUtc.isBefore(state.endDateTime)) {
+      state = state.copyWith(startDateTime: startDateTimeUtc, startDateTimeText: dateTimeText);
       return;
     }
 
-    final endTime = state.isWholeDay ? dateTime : dateTime.add(const Duration(hours: 1));
+    final endTime = state.isWholeDay ? startDateTimeUtc : startDateTimeUtc.add(const Duration(hours: 1));
 
     state = state.copyWith(
-      startDateTime: dateTime,
+      startDateTime: startDateTimeUtc,
       startDateTimeText: dateTimeText,
       endDateTime: endTime,
       endDateTimeText: _getDateTimeText(endTime, state.isWholeDay),
     );
   }
 
-  void setEndDateTime(final DateTime dateTime) {
-    final dateTimeText = _getDateTimeText(dateTime, state.isWholeDay);
-    state = state.copyWith(endDateTime: dateTime, endDateTimeText: dateTimeText);
+  void setEndDateTime(final DateTime endDateTime) {
+    final endDateTimeUtc = endDateTime.toUtc();
+    final dateTimeText = _getDateTimeText(endDateTime, state.isWholeDay);
+    state = state.copyWith(endDateTime: endDateTimeUtc, endDateTimeText: dateTimeText);
   }
 
   void setDescription(final String description) {

--- a/lib/presentation/state/schedule_create_state.dart
+++ b/lib/presentation/state/schedule_create_state.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:schedule_management_app/domain/calculator/datetime_calculator.dart';
 import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
 import 'package:schedule_management_app/presentation/view/view_model/schedule_create_view_model.dart';
 
@@ -46,27 +47,25 @@ class ScheduleCreateState extends StateNotifier<ScheduleCreateViewModel> {
   }
 
   void setStartDateTime(final DateTime startDateTime) {
-    final dateTimeText = _getDateTimeText(startDateTime.toLocal(), state.isWholeDay);
-
-    if (startDateTime.isBefore(state.endDateTime)) {
-      state = state.copyWith(startDateTime: startDateTime, startDateTimeText: dateTimeText);
-      return;
-    }
-
-    final endTime = state.isWholeDay ? startDateTime : startDateTime.add(const Duration(hours: 1));
+    final clampedEndDateTime = DateTimeCalculator.getClampedEndDateTime(startDateTime, state.endDateTime);
 
     state = state.copyWith(
       startDateTime: startDateTime,
-      startDateTimeText: dateTimeText,
-      endDateTime: endTime,
-      endDateTimeText: _getDateTimeText(endTime, state.isWholeDay),
+      startDateTimeText: _getDateTimeText(startDateTime, state.isWholeDay),
+      endDateTime: clampedEndDateTime,
+      endDateTimeText: _getDateTimeText(clampedEndDateTime, state.isWholeDay),
     );
   }
 
   void setEndDateTime(final DateTime endDateTime) {
-    final endDateTimeUtc = endDateTime.toUtc();
-    final dateTimeText = _getDateTimeText(endDateTime, state.isWholeDay);
-    state = state.copyWith(endDateTime: endDateTimeUtc, endDateTimeText: dateTimeText);
+    final clampedStartDateTime = DateTimeCalculator.getClampedStartDateTime(state.startDateTime, endDateTime);
+
+    state = state.copyWith(
+      startDateTime: clampedStartDateTime,
+      startDateTimeText: _getDateTimeText(clampedStartDateTime, state.isWholeDay),
+      endDateTime: endDateTime,
+      endDateTimeText: _getDateTimeText(endDateTime, state.isWholeDay),
+    );
   }
 
   void setDescription(final String description) {

--- a/lib/presentation/state/schedule_edit_state.dart
+++ b/lib/presentation/state/schedule_edit_state.dart
@@ -30,8 +30,7 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
   }
 
   void setTitle(final String title) {
-    state = state.copyWith(title: title, canSave: true);
-    _updateIsModified();
+    state = state.copyWith(title: title, canSave: true, isModified: true);
   }
 
   void setWholeDay(final bool isWholeDay) {
@@ -40,6 +39,7 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
       startDateTimeText: _getDateTimeText(state.startDateTime, isWholeDay),
       endDateTimeText: _getDateTimeText(state.endDateTime, isWholeDay),
       canSave: true,
+      isModified: true,
     );
   }
 
@@ -51,6 +51,7 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
         startDateTime: startDateTime,
         startDateTimeText: dateTimeText,
         canSave: true,
+        isModified: true,
       );
       return;
     }
@@ -63,6 +64,7 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
       endDateTime: endTime,
       endDateTimeText: _getDateTimeText(endTime, state.isWholeDay),
       canSave: true,
+      isModified: true,
     );
   }
 
@@ -73,18 +75,16 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
       endDateTime: endDateTimeUtc,
       endDateTimeText: dateTimeText,
       canSave: true,
+      isModified: true,
     );
   }
 
   void setDescription(final String description) {
-    state = state.copyWith(description: description, canSave: true);
-    _updateIsModified();
-  }
-
-  // TODO 中の処理を考える
-  void _updateIsModified() {
-    final isModified = state.title.isNotEmpty || state.description.isNotEmpty;
-    state = state.copyWith(isModified: isModified);
+    state = state.copyWith(
+      description: description,
+      canSave: true,
+      isModified: true,
+    );
   }
 
   String _getDateTimeText(final DateTime dateTime, final bool isWholeDay) {

--- a/lib/presentation/state/schedule_edit_state.dart
+++ b/lib/presentation/state/schedule_edit_state.dart
@@ -30,8 +30,7 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
   }
 
   void setTitle(final String title) {
-    state = state.copyWith(title: title);
-    _updateCanSave();
+    state = state.copyWith(title: title, canSave: true);
     _updateIsModified();
   }
 
@@ -40,6 +39,7 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
       isWholeDay: isWholeDay,
       startDateTimeText: _getDateTimeText(state.startDateTime, isWholeDay),
       endDateTimeText: _getDateTimeText(state.endDateTime, isWholeDay),
+      canSave: true,
     );
   }
 
@@ -47,7 +47,11 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
     final dateTimeText = _getDateTimeText(startDateTime.toLocal(), state.isWholeDay);
 
     if (startDateTime.isBefore(state.endDateTime)) {
-      state = state.copyWith(startDateTime: startDateTime, startDateTimeText: dateTimeText);
+      state = state.copyWith(
+        startDateTime: startDateTime,
+        startDateTimeText: dateTimeText,
+        canSave: true,
+      );
       return;
     }
 
@@ -58,25 +62,23 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
       startDateTimeText: dateTimeText,
       endDateTime: endTime,
       endDateTimeText: _getDateTimeText(endTime, state.isWholeDay),
+      canSave: true,
     );
   }
 
   void setEndDateTime(final DateTime endDateTime) {
     final endDateTimeUtc = endDateTime.toUtc();
     final dateTimeText = _getDateTimeText(endDateTime, state.isWholeDay);
-    state = state.copyWith(endDateTime: endDateTimeUtc, endDateTimeText: dateTimeText);
+    state = state.copyWith(
+      endDateTime: endDateTimeUtc,
+      endDateTimeText: dateTimeText,
+      canSave: true,
+    );
   }
 
   void setDescription(final String description) {
-    state = state.copyWith(description: description);
-    _updateCanSave();
+    state = state.copyWith(description: description, canSave: true);
     _updateIsModified();
-  }
-
-  // TODO 中の処理を考える
-  void _updateCanSave() {
-    final canSave = state.title.isNotEmpty && state.description.isNotEmpty;
-    state = state.copyWith(canSave: canSave);
   }
 
   // TODO 中の処理を考える

--- a/lib/presentation/state/schedule_edit_state.dart
+++ b/lib/presentation/state/schedule_edit_state.dart
@@ -1,0 +1,92 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
+import 'package:schedule_management_app/presentation/view/view_model/schedule_edit_view_model.dart';
+
+class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
+  ScheduleEditState(final ScheduleEditViewModel state) : super(state);
+
+  ScheduleEditViewModel get viewModel => state;
+
+  void set(
+    String title,
+    bool isWholeDay,
+    DateTime startDateTime,
+    DateTime endDateTime,
+    String description,
+  ) {
+    state = state.copyWith(
+      maximumYear: startDateTime.year + 100,
+      title: title,
+      isWholeDay: isWholeDay,
+      startDateTime: startDateTime,
+      endDateTime: endDateTime,
+      startDateTimeText: _getDateTimeText(startDateTime, isWholeDay),
+      endDateTimeText: _getDateTimeText(endDateTime, isWholeDay),
+      description: description,
+    );
+  }
+
+  void setTitle(final String title) {
+    state = state.copyWith(title: title);
+    _updateCanSave();
+    _updateIsModified();
+  }
+
+  void setWholeDay(final bool isWholeDay) {
+    state = state.copyWith(
+      isWholeDay: isWholeDay,
+      startDateTimeText: _getDateTimeText(state.startDateTime, isWholeDay),
+      endDateTimeText: _getDateTimeText(state.endDateTime, isWholeDay),
+    );
+  }
+
+  void setStartDateTime(final DateTime startDateTime) {
+    final dateTimeText = _getDateTimeText(startDateTime.toLocal(), state.isWholeDay);
+
+    if (startDateTime.isBefore(state.endDateTime)) {
+      state = state.copyWith(startDateTime: startDateTime, startDateTimeText: dateTimeText);
+      return;
+    }
+
+    final endTime = state.isWholeDay ? startDateTime : startDateTime.add(const Duration(hours: 1));
+
+    state = state.copyWith(
+      startDateTime: startDateTime,
+      startDateTimeText: dateTimeText,
+      endDateTime: endTime,
+      endDateTimeText: _getDateTimeText(endTime, state.isWholeDay),
+    );
+  }
+
+  void setEndDateTime(final DateTime endDateTime) {
+    final endDateTimeUtc = endDateTime.toUtc();
+    final dateTimeText = _getDateTimeText(endDateTime, state.isWholeDay);
+    state = state.copyWith(endDateTime: endDateTimeUtc, endDateTimeText: dateTimeText);
+  }
+
+  void setDescription(final String description) {
+    state = state.copyWith(description: description);
+    _updateCanSave();
+    _updateIsModified();
+  }
+
+  // TODO 中の処理を考える
+  void _updateCanSave() {
+    final canSave = state.title.isNotEmpty && state.description.isNotEmpty;
+    state = state.copyWith(canSave: canSave);
+  }
+
+  // TODO 中の処理を考える
+  void _updateIsModified() {
+    final isModified = state.title.isNotEmpty || state.description.isNotEmpty;
+    state = state.copyWith(isModified: isModified);
+  }
+
+  String _getDateTimeText(final DateTime dateTime, final bool isWholeDay) {
+    return DateFormat(isWholeDay
+            ? TextConstants.wholeDaySwitchOnDateFormat
+            : TextConstants.wholeDaySwitchOffDateFormat)
+        .format(dateTime);
+  }
+}

--- a/lib/presentation/state/schedule_edit_state.dart
+++ b/lib/presentation/state/schedule_edit_state.dart
@@ -9,6 +9,7 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
   ScheduleEditViewModel get viewModel => state;
 
   void set(
+    int scheduleId,
     String title,
     bool isWholeDay,
     DateTime startDateTime,
@@ -16,6 +17,7 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
     String description,
   ) {
     state = state.copyWith(
+      scheduleId: scheduleId,
       maximumYear: startDateTime.year + 100,
       title: title,
       isWholeDay: isWholeDay,

--- a/lib/presentation/state/schedule_edit_state.dart
+++ b/lib/presentation/state/schedule_edit_state.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:schedule_management_app/domain/calculator/datetime_calculator.dart';
 import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
 import 'package:schedule_management_app/presentation/view/view_model/schedule_edit_view_model.dart';
 
@@ -44,36 +45,26 @@ class ScheduleEditState extends StateNotifier<ScheduleEditViewModel> {
   }
 
   void setStartDateTime(final DateTime startDateTime) {
-    final dateTimeText = _getDateTimeText(startDateTime.toLocal(), state.isWholeDay);
-
-    if (startDateTime.isBefore(state.endDateTime)) {
-      state = state.copyWith(
-        startDateTime: startDateTime,
-        startDateTimeText: dateTimeText,
-        canSave: true,
-        isModified: true,
-      );
-      return;
-    }
-
-    final endTime = state.isWholeDay ? startDateTime : startDateTime.add(const Duration(hours: 1));
+    final clampedEndDateTime = DateTimeCalculator.getClampedEndDateTime(startDateTime, state.endDateTime);
 
     state = state.copyWith(
       startDateTime: startDateTime,
-      startDateTimeText: dateTimeText,
-      endDateTime: endTime,
-      endDateTimeText: _getDateTimeText(endTime, state.isWholeDay),
+      startDateTimeText: _getDateTimeText(startDateTime, state.isWholeDay),
+      endDateTime: clampedEndDateTime,
+      endDateTimeText: _getDateTimeText(clampedEndDateTime, state.isWholeDay),
       canSave: true,
       isModified: true,
     );
   }
 
   void setEndDateTime(final DateTime endDateTime) {
-    final endDateTimeUtc = endDateTime.toUtc();
-    final dateTimeText = _getDateTimeText(endDateTime, state.isWholeDay);
+    final clampedStartDateTime = DateTimeCalculator.getClampedStartDateTime(state.startDateTime, endDateTime);
+
     state = state.copyWith(
-      endDateTime: endDateTimeUtc,
-      endDateTimeText: dateTimeText,
+      startDateTime: clampedStartDateTime,
+      startDateTimeText: _getDateTimeText(clampedStartDateTime, state.isWholeDay),
+      endDateTime: endDateTime,
+      endDateTimeText: _getDateTimeText(endDateTime, state.isWholeDay),
       canSave: true,
       isModified: true,
     );

--- a/lib/presentation/state/schedule_list_state.dart
+++ b/lib/presentation/state/schedule_list_state.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';

--- a/lib/presentation/state/schedule_list_state.dart
+++ b/lib/presentation/state/schedule_list_state.dart
@@ -1,16 +1,50 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:schedule_management_app/presentation/view/constants/schedule_list_constants.dart';
 import 'package:schedule_management_app/presentation/view/view_model/schedule_list_element_model.dart';
 import 'package:schedule_management_app/presentation/view/view_model/schedule_list_view_model.dart';
 
 class ScheduleListState extends StateNotifier<ScheduleListViewModel> {
   ScheduleListState(final ScheduleListViewModel state) : super(state);
+
   ScheduleListViewModel get viewModel => state;
 
-  void setSelectedDay(final DateTime selectedDay) {
-    state = state.copyWith(selectedDateTime: selectedDay);
+  void setSelectedDay(final DateTime selectedDateTime) {
+    final selectedDateTimeText = DateFormat(
+      ScheduleListConstants.dateTimeFormat,
+      ScheduleListConstants.scheduleListLocale,
+    ).format(selectedDateTime);
+
+    final weekDayText = DateFormat(
+      ScheduleListConstants.dateTimeWeekDayFormat,
+      ScheduleListConstants.scheduleListLocale,
+    ).format(selectedDateTime);
+
+    final weekDayColor = _getWeekDayColor(selectedDateTime);
+
+    state = state.copyWith(
+      selectedDateTime: selectedDateTime,
+      selectedDateTimeText: selectedDateTimeText,
+      weekDayText: weekDayText,
+      weekDayColor: weekDayColor,
+    );
   }
 
   void setScheduleElements(final List<ScheduleListElementModel> scheduleElements) {
     state = state.copyWith(scheduleElements: scheduleElements);
+  }
+
+  Color _getWeekDayColor(DateTime dateTime) {
+    switch (dateTime.weekday) {
+      case DateTime.saturday:
+        return Colors.blue;
+      case DateTime.sunday:
+        return Colors.red;
+      default:
+        return Colors.black;
+    }
   }
 }

--- a/lib/presentation/state/schedule_list_state.dart
+++ b/lib/presentation/state/schedule_list_state.dart
@@ -7,7 +7,7 @@ class ScheduleListState extends StateNotifier<ScheduleListViewModel> {
   ScheduleListViewModel get viewModel => state;
 
   void setSelectedDay(final DateTime selectedDay) {
-    state = state.copyWith(selectedDay: selectedDay);
+    state = state.copyWith(selectedDateTime: selectedDay);
   }
 
   void setScheduleElements(final List<ScheduleListElementModel> scheduleElements) {

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -22,8 +22,9 @@ class ScheduleComponent extends StatelessWidget {
   final bool _isModified;
   final VoidCallback _onPressedSave;
   final VoidCallback _onDiscard;
+  final FocusNode _focusNode = FocusNode();
 
-  const ScheduleComponent({
+  ScheduleComponent({
     final Key? key,
     required final String appBarText,
     required final String title,
@@ -63,83 +64,90 @@ class ScheduleComponent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(_appBarText),
-        centerTitle: true,
-        leading: IconButton(
-          icon: const Icon(Icons.close),
-          onPressed: () async => await _closeView(context),
-        ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: ElevatedButton(
-              child: const Text(ScheduleComponentConstants.save),
-              onPressed: _getSaveCallback(context),
+    return Focus(
+      focusNode: _focusNode,
+      child: GestureDetector(
+        onTap: _focusNode.requestFocus,
+        child: Scaffold(
+          resizeToAvoidBottomInset: false,
+          appBar: AppBar(
+            title: Text(_appBarText),
+            centerTitle: true,
+            leading: IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: () async => await _closeView(context),
             ),
-          )
-        ],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          children: [
-            TextFormField(
-              initialValue: _title,
-              autofocus: true,
-              decoration: const InputDecoration(
-                hintText: ScheduleComponentConstants.titleHintText,
-                border: OutlineInputBorder(),
-              ),
-              onChanged: _onTitleChanged,
-            ),
-            SwitchListTile(
-              title: const Text(ScheduleComponentConstants.wholeDay),
-              value: _isWholeDay,
-              onChanged: _onWholeDayChanged,
-            ),
-            WidgetFactory.createDatePickerButton(
-              context,
-              ScheduleComponentConstants.start,
-              _startDateTimeText,
-              () {
-                _showDateTimePicker(
-                  context,
-                  _startDateTime,
-                  _startDateTime.year + 100,
-                  _isWholeDay,
-                  _onStartDateTimeChanged,
-                );
-              },
-            ),
-            WidgetFactory.createDatePickerButton(
-              context,
-              ScheduleComponentConstants.end,
-              _endDateTimeText,
-              () {
-                _showDateTimePicker(
-                  context,
-                  _endDateTime,
-                  _startDateTime.year + 100,
-                  _isWholeDay,
-                  _onEndDateTimeChanged,
-                );
-              },
-            ),
-            Expanded(
-              child: TextFormField(
-                initialValue: _description,
-                decoration: const InputDecoration(
-                  hintText: ScheduleComponentConstants.descriptionHintText,
-                  border: OutlineInputBorder(),
+            actions: [
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: ElevatedButton(
+                  child: const Text(ScheduleComponentConstants.save),
+                  onPressed: _getSaveCallback(context),
                 ),
-                keyboardType: TextInputType.multiline,
-                maxLines: null,
-                onChanged: _onDescriptionChanged,
-              ),
+              )
+            ],
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              children: [
+                TextFormField(
+                  initialValue: _title,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    hintText: ScheduleComponentConstants.titleHintText,
+                    border: OutlineInputBorder(),
+                  ),
+                  onChanged: _onTitleChanged,
+                ),
+                SwitchListTile(
+                  title: const Text(ScheduleComponentConstants.wholeDay),
+                  value: _isWholeDay,
+                  onChanged: _onWholeDayChanged,
+                ),
+                WidgetFactory.createDatePickerButton(
+                  context,
+                  ScheduleComponentConstants.start,
+                  _startDateTimeText,
+                  () {
+                    _showDateTimePicker(
+                      context,
+                      _startDateTime,
+                      _startDateTime.year + 100,
+                      _isWholeDay,
+                      _onStartDateTimeChanged,
+                    );
+                  },
+                ),
+                WidgetFactory.createDatePickerButton(
+                  context,
+                  ScheduleComponentConstants.end,
+                  _endDateTimeText,
+                  () {
+                    _showDateTimePicker(
+                      context,
+                      _endDateTime,
+                      _startDateTime.year + 100,
+                      _isWholeDay,
+                      _onEndDateTimeChanged,
+                    );
+                  },
+                ),
+                Expanded(
+                  child: TextFormField(
+                    initialValue: _description,
+                    decoration: const InputDecoration(
+                      hintText: ScheduleComponentConstants.descriptionHintText,
+                      border: OutlineInputBorder(),
+                    ),
+                    keyboardType: TextInputType.multiline,
+                    maxLines: null,
+                    onChanged: _onDescriptionChanged,
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -69,7 +69,7 @@ class ScheduleComponent extends StatelessWidget {
         centerTitle: true,
         leading: IconButton(
           icon: const Icon(Icons.close),
-          onPressed: () => _closeView(context),
+          onPressed: () async => await _closeView(context),
         ),
         actions: [
           Padding(
@@ -194,27 +194,27 @@ class ScheduleComponent extends StatelessWidget {
     };
   }
 
-  void _closeView(final BuildContext context) {
+  Future<void> _closeView(final BuildContext context) async {
     if (_isModified) {
-      _showModifiedPopup(context);
-    } else {
-      Navigator.pop(context);
-      _onDiscard();
+      return await _showModifiedPopup(context);
     }
+
+    Navigator.pop(context);
+    _onDiscard();
   }
 
-  Future<dynamic> _showModifiedPopup(final BuildContext context) {
-    return showCupertinoModalPopup(
+  Future<void> _showModifiedPopup(final BuildContext context) async {
+    var isDiscarded = false;
+
+    final popup = showCupertinoModalPopup(
       context: context,
       builder: (BuildContext context) {
         return CupertinoActionSheet(
           actions: [
             CupertinoActionSheetAction(
               onPressed: () {
-                // TODO 2回ポップするもっと良い方法を調べる
                 Navigator.of(context).pop();
-                Navigator.of(context).pop();
-                _onDiscard();
+                isDiscarded = true;
               },
               child: const Text(ScheduleComponentConstants.confirmationDiscard),
             ),
@@ -226,5 +226,14 @@ class ScheduleComponent extends StatelessWidget {
         );
       },
     );
+
+    await popup;
+
+    if (!isDiscarded) {
+      return;
+    }
+
+    _onDiscard();
+    Navigator.pop(context);
   }
 }

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:schedule_management_app/presentation/view/constants/schedule_create_constants.dart';
+import 'package:schedule_management_app/presentation/view/factory/widget_factory.dart';
+
+class ScheduleComponent extends StatelessWidget {
+  final String _title;
+  final TextEditingController _titleTextEditingController;
+  final ValueChanged<String> _onTitleChanged;
+  final bool _isWholeDay;
+  final ValueChanged<bool> _onWholeDayChanged;
+  final DateTime _startDateTime;
+  final DateTime _endDateTime;
+  final String _startDateTimeText;
+  final String _endDateTimeText;
+  final ValueChanged<DateTime> _onStartDateTimeChanged;
+  final ValueChanged<DateTime> _onEndDateTimeChanged;
+  final TextEditingController _descriptionTextEditingController;
+  final ValueChanged<String> _onDescriptionChanged;
+  final VoidCallback? _onPressedSave;
+
+  const ScheduleComponent({
+    final Key? key,
+    required final String appBarText,
+    required final TextEditingController titleTextEditingController,
+    required final ValueChanged<String> onTitleChanged,
+    required final bool isWholeDay,
+    required final ValueChanged<bool> onWholeDayChanged,
+    required final DateTime startDateTime,
+    required final DateTime endDateTime,
+    required final String startDateTimeText,
+    required final String endDateTimeText,
+    required final ValueChanged<DateTime> onStartDateTimeChanged,
+    required final ValueChanged<DateTime> onEndDateTimeChanged,
+    required final TextEditingController descriptionTextEditingController,
+    required final ValueChanged<String> onDescriptionChanged,
+    required final VoidCallback? onPressedSave,
+  })  : _title = appBarText,
+        _titleTextEditingController = titleTextEditingController,
+        _onTitleChanged = onTitleChanged,
+        _isWholeDay = isWholeDay,
+        _onWholeDayChanged = onWholeDayChanged,
+        _startDateTime = startDateTime,
+        _endDateTime = endDateTime,
+        _startDateTimeText = startDateTimeText,
+        _endDateTimeText = endDateTimeText,
+        _onStartDateTimeChanged = onStartDateTimeChanged,
+        _onEndDateTimeChanged = onEndDateTimeChanged,
+        _descriptionTextEditingController = descriptionTextEditingController,
+        _onDescriptionChanged = onDescriptionChanged,
+        _onPressedSave = onPressedSave,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_title),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              child: const Text('保存'),
+              onPressed: _onPressedSave,
+            ),
+          )
+        ],
+      ),
+      body: Column(
+        children: [
+          TextField(
+            controller: _titleTextEditingController,
+            autofocus: true,
+            decoration: const InputDecoration(
+              hintText: 'タイトルを入力してください',
+            ),
+            onChanged: _onTitleChanged,
+          ),
+          Row(
+            children: [
+              const Text('終日'),
+              Switch(
+                value: _isWholeDay,
+                onChanged: _onWholeDayChanged,
+              ),
+            ],
+          ),
+          WidgetFactory.createDatePickerButton(
+            context,
+            '開始',
+            _startDateTimeText,
+            () {
+              _showDateTimePicker(
+                context,
+                _startDateTime,
+                _startDateTime.year + 100,
+                _isWholeDay,
+                _onStartDateTimeChanged,
+              );
+            },
+          ),
+          WidgetFactory.createDatePickerButton(
+            context,
+            '終了',
+            _endDateTimeText,
+            () {
+              _showDateTimePicker(
+                context,
+                _endDateTime,
+                _startDateTime.year + 100,
+                _isWholeDay,
+                _onEndDateTimeChanged,
+              );
+            },
+          ),
+          Expanded(
+            child: TextField(
+              controller: _descriptionTextEditingController,
+              decoration: const InputDecoration(
+                hintText: 'コメントを入力してください',
+              ),
+              keyboardType: TextInputType.multiline,
+              maxLines: null,
+              onChanged: _onDescriptionChanged,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showDateTimePicker(
+    final BuildContext context,
+    final DateTime initialDateTime,
+    final int maximumYear,
+    final bool isWholeDay,
+    final ValueChanged<DateTime> onDateTimeChanged,
+  ) {
+    showCupertinoModalPopup(
+      context: context,
+      builder: (context) {
+        return Container(
+          height: 300.0,
+          color: Colors.white,
+          child: Column(
+            children: [
+              SizedBox(
+                height: 300.0,
+                child: CupertinoDatePicker(
+                  minuteInterval: 15,
+                  use24hFormat: true,
+                  mode: isWholeDay
+                      ? CupertinoDatePickerMode.date
+                      : CupertinoDatePickerMode.dateAndTime,
+                  dateOrder: DatePickerDateOrder.ymd,
+                  minimumYear: ScheduleCreateConstants.minimumYear,
+                  maximumYear: maximumYear,
+                  initialDateTime: initialDateTime,
+                  onDateTimeChanged: onDateTimeChanged,
+                ),
+              )
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -19,7 +19,9 @@ class ScheduleComponent extends StatelessWidget {
   final TextEditingController _descriptionTextEditingController;
   final ValueChanged<String> _onDescriptionChanged;
   final bool _canSave;
+  final bool _isModified;
   final VoidCallback _onPressedSave;
+  final VoidCallback _onDiscard;
 
   const ScheduleComponent({
     final Key? key,
@@ -37,7 +39,9 @@ class ScheduleComponent extends StatelessWidget {
     required final TextEditingController descriptionTextEditingController,
     required final ValueChanged<String> onDescriptionChanged,
     required final bool canSave,
+    required final bool isModified,
     required final VoidCallback onPressedSave,
+    required final VoidCallback onDiscard,
   })  : _title = appBarText,
         _titleTextEditingController = titleTextEditingController,
         _onTitleChanged = onTitleChanged,
@@ -52,7 +56,9 @@ class ScheduleComponent extends StatelessWidget {
         _descriptionTextEditingController = descriptionTextEditingController,
         _onDescriptionChanged = onDescriptionChanged,
         _canSave = canSave,
+        _isModified = isModified,
         _onPressedSave = onPressedSave,
+        _onDiscard = onDiscard,
         super(key: key);
 
   @override
@@ -63,7 +69,7 @@ class ScheduleComponent extends StatelessWidget {
         centerTitle: true,
         leading: IconButton(
           icon: const Icon(Icons.close),
-          onPressed: () => Navigator.pop(context),
+          onPressed: () => _closeView(context),
         ),
         actions: [
           Padding(
@@ -185,5 +191,39 @@ class ScheduleComponent extends StatelessWidget {
       _onPressedSave();
       Navigator.pop(context);
     };
+  }
+
+  void _closeView(final BuildContext context) {
+    if (_isModified) {
+      _showModifiedPopup(context);
+    } else {
+      Navigator.pop(context);
+      _onDiscard();
+    }
+  }
+
+  Future<dynamic> _showModifiedPopup(final BuildContext context) {
+    return showCupertinoModalPopup(
+      context: context,
+      builder: (BuildContext context) {
+        return CupertinoActionSheet(
+          actions: [
+            CupertinoActionSheetAction(
+              onPressed: () {
+                // TODO 2回ポップするもっと良い方法を調べる
+                Navigator.of(context).pop();
+                Navigator.of(context).pop();
+                _onDiscard();
+              },
+              child: const Text(ScheduleComponentConstants.confirmationDiscard),
+            ),
+            CupertinoActionSheetAction(
+              onPressed: () => Navigator.pop(context),
+              child: const Text(ScheduleComponentConstants.confirmationCancel),
+            ),
+          ],
+        );
+      },
+    );
   }
 }

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -20,7 +20,7 @@ class ScheduleComponent extends StatelessWidget {
   final ValueChanged<String> _onDescriptionChanged;
   final bool _canSave;
   final bool _isModified;
-  final VoidCallback _onPressedSave;
+  final Function _onPressedSave;
   final VoidCallback _onDiscard;
   final FocusNode _focusNode = FocusNode();
 
@@ -41,7 +41,7 @@ class ScheduleComponent extends StatelessWidget {
     required final ValueChanged<String> onDescriptionChanged,
     required final bool canSave,
     required final bool isModified,
-    required final VoidCallback onPressedSave,
+    required final Function onPressedSave,
     required final VoidCallback onDiscard,
   })  : _appBarText = appBarText,
         _title = title,
@@ -195,8 +195,8 @@ class ScheduleComponent extends StatelessWidget {
       return null;
     }
 
-    return () {
-      _onPressedSave();
+    return () async {
+      await _onPressedSave();
       Navigator.pop(context);
       _onDiscard();
     };

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -75,65 +75,66 @@ class ScheduleComponent extends StatelessWidget {
           )
         ],
       ),
-      body: Column(
-        children: [
-          TextField(
-            controller: _titleTextEditingController,
-            autofocus: true,
-            decoration: const InputDecoration(
-              hintText: ScheduleComponentConstants.titleHintText,
-            ),
-            onChanged: _onTitleChanged,
-          ),
-          Row(
-            children: [
-              const Text(ScheduleComponentConstants.wholeDay),
-              Switch(
-                value: _isWholeDay,
-                onChanged: _onWholeDayChanged,
-              ),
-            ],
-          ),
-          WidgetFactory.createDatePickerButton(
-            context,
-            ScheduleComponentConstants.start,
-            _startDateTimeText,
-            () {
-              _showDateTimePicker(
-                context,
-                _startDateTime,
-                _startDateTime.year + 100,
-                _isWholeDay,
-                _onStartDateTimeChanged,
-              );
-            },
-          ),
-          WidgetFactory.createDatePickerButton(
-            context,
-            ScheduleComponentConstants.end,
-            _endDateTimeText,
-            () {
-              _showDateTimePicker(
-                context,
-                _endDateTime,
-                _startDateTime.year + 100,
-                _isWholeDay,
-                _onEndDateTimeChanged,
-              );
-            },
-          ),
-          Expanded(
-            child: TextField(
-              controller: _descriptionTextEditingController,
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleTextEditingController,
+              autofocus: true,
               decoration: const InputDecoration(
-                hintText: ScheduleComponentConstants.descriptionHintText,
+                hintText: ScheduleComponentConstants.titleHintText,
+                border: OutlineInputBorder(),
               ),
-              keyboardType: TextInputType.multiline,
-              maxLines: null,
-              onChanged: _onDescriptionChanged,
+              onChanged: _onTitleChanged,
             ),
-          ),
-        ],
+            SwitchListTile(
+              title: const Text(ScheduleComponentConstants.wholeDay),
+              value: _isWholeDay,
+              onChanged: _onWholeDayChanged,
+            ),
+            WidgetFactory.createDatePickerButton(
+              context,
+              ScheduleComponentConstants.start,
+              _startDateTimeText,
+              () {
+                _showDateTimePicker(
+                  context,
+                  _startDateTime,
+                  _startDateTime.year + 100,
+                  _isWholeDay,
+                  _onStartDateTimeChanged,
+                );
+              },
+            ),
+            WidgetFactory.createDatePickerButton(
+              context,
+              ScheduleComponentConstants.end,
+              _endDateTimeText,
+              () {
+                _showDateTimePicker(
+                  context,
+                  _endDateTime,
+                  _startDateTime.year + 100,
+                  _isWholeDay,
+                  _onEndDateTimeChanged,
+                );
+              },
+            ),
+            Expanded(
+              child: TextField(
+                controller: _descriptionTextEditingController,
+                decoration: const InputDecoration(
+                  hintText: ScheduleComponentConstants.descriptionHintText,
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.multiline,
+                maxLines: null,
+                onChanged: _onDescriptionChanged,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -176,7 +177,7 @@ class ScheduleComponent extends StatelessWidget {
   }
 
   VoidCallback? _getSaveCallback(BuildContext context) {
-    if(!_canSave) {
+    if (!_canSave) {
       return null;
     }
 

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:schedule_management_app/presentation/view/constants/schedule_component_constants.dart';
 import 'package:schedule_management_app/presentation/view/constants/schedule_create_constants.dart';
 import 'package:schedule_management_app/presentation/view/factory/widget_factory.dart';
 
@@ -65,7 +66,7 @@ class ScheduleComponent extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
-              child: const Text('保存'),
+              child: const Text(ScheduleComponentConstants.save),
               onPressed: _onPressedSave,
             ),
           )
@@ -77,13 +78,13 @@ class ScheduleComponent extends StatelessWidget {
             controller: _titleTextEditingController,
             autofocus: true,
             decoration: const InputDecoration(
-              hintText: 'タイトルを入力してください',
+              hintText: ScheduleComponentConstants.titleHintText,
             ),
             onChanged: _onTitleChanged,
           ),
           Row(
             children: [
-              const Text('終日'),
+              const Text(ScheduleComponentConstants.wholeDay),
               Switch(
                 value: _isWholeDay,
                 onChanged: _onWholeDayChanged,
@@ -92,7 +93,7 @@ class ScheduleComponent extends StatelessWidget {
           ),
           WidgetFactory.createDatePickerButton(
             context,
-            '開始',
+            ScheduleComponentConstants.start,
             _startDateTimeText,
             () {
               _showDateTimePicker(
@@ -106,7 +107,7 @@ class ScheduleComponent extends StatelessWidget {
           ),
           WidgetFactory.createDatePickerButton(
             context,
-            '終了',
+            ScheduleComponentConstants.end,
             _endDateTimeText,
             () {
               _showDateTimePicker(
@@ -122,7 +123,7 @@ class ScheduleComponent extends StatelessWidget {
             child: TextField(
               controller: _descriptionTextEditingController,
               decoration: const InputDecoration(
-                hintText: 'コメントを入力してください',
+                hintText: ScheduleComponentConstants.descriptionHintText,
               ),
               keyboardType: TextInputType.multiline,
               maxLines: null,

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -89,52 +89,52 @@ class ScheduleComponent extends StatelessWidget {
           ),
           body: Padding(
             padding: const EdgeInsets.all(8.0),
-            child: Column(
-              children: [
-                TextFormField(
-                  initialValue: _title,
-                  autofocus: true,
-                  decoration: const InputDecoration(
-                    hintText: ScheduleComponentConstants.titleHintText,
-                    border: OutlineInputBorder(),
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  TextFormField(
+                    initialValue: _title,
+                    autofocus: true,
+                    decoration: const InputDecoration(
+                      hintText: ScheduleComponentConstants.titleHintText,
+                      border: OutlineInputBorder(),
+                    ),
+                    onChanged: _onTitleChanged,
                   ),
-                  onChanged: _onTitleChanged,
-                ),
-                SwitchListTile(
-                  title: const Text(ScheduleComponentConstants.wholeDay),
-                  value: _isWholeDay,
-                  onChanged: _onWholeDayChanged,
-                ),
-                WidgetFactory.createDatePickerButton(
-                  context,
-                  ScheduleComponentConstants.start,
-                  _startDateTimeText,
-                  () {
-                    _showDateTimePicker(
-                      context,
-                      _startDateTime,
-                      _startDateTime.year + 100,
-                      _isWholeDay,
-                      _onStartDateTimeChanged,
-                    );
-                  },
-                ),
-                WidgetFactory.createDatePickerButton(
-                  context,
-                  ScheduleComponentConstants.end,
-                  _endDateTimeText,
-                  () {
-                    _showDateTimePicker(
-                      context,
-                      _endDateTime,
-                      _startDateTime.year + 100,
-                      _isWholeDay,
-                      _onEndDateTimeChanged,
-                    );
-                  },
-                ),
-                Expanded(
-                  child: TextFormField(
+                  SwitchListTile(
+                    title: const Text(ScheduleComponentConstants.wholeDay),
+                    value: _isWholeDay,
+                    onChanged: _onWholeDayChanged,
+                  ),
+                  WidgetFactory.createDatePickerButton(
+                    context,
+                    ScheduleComponentConstants.start,
+                    _startDateTimeText,
+                    () {
+                      _showDateTimePicker(
+                        context,
+                        _startDateTime,
+                        _startDateTime.year + 100,
+                        _isWholeDay,
+                        _onStartDateTimeChanged,
+                      );
+                    },
+                  ),
+                  WidgetFactory.createDatePickerButton(
+                    context,
+                    ScheduleComponentConstants.end,
+                    _endDateTimeText,
+                    () {
+                      _showDateTimePicker(
+                        context,
+                        _endDateTime,
+                        _startDateTime.year + 100,
+                        _isWholeDay,
+                        _onEndDateTimeChanged,
+                      );
+                    },
+                  ),
+                  TextFormField(
                     initialValue: _description,
                     decoration: const InputDecoration(
                       hintText: ScheduleComponentConstants.descriptionHintText,
@@ -144,8 +144,8 @@ class ScheduleComponent extends StatelessWidget {
                     maxLines: null,
                     onChanged: _onDescriptionChanged,
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -18,7 +18,8 @@ class ScheduleComponent extends StatelessWidget {
   final ValueChanged<DateTime> _onEndDateTimeChanged;
   final TextEditingController _descriptionTextEditingController;
   final ValueChanged<String> _onDescriptionChanged;
-  final VoidCallback? _onPressedSave;
+  final bool _canSave;
+  final VoidCallback _onPressedSave;
 
   const ScheduleComponent({
     final Key? key,
@@ -35,7 +36,8 @@ class ScheduleComponent extends StatelessWidget {
     required final ValueChanged<DateTime> onEndDateTimeChanged,
     required final TextEditingController descriptionTextEditingController,
     required final ValueChanged<String> onDescriptionChanged,
-    required final VoidCallback? onPressedSave,
+    required final bool canSave,
+    required final VoidCallback onPressedSave,
   })  : _title = appBarText,
         _titleTextEditingController = titleTextEditingController,
         _onTitleChanged = onTitleChanged,
@@ -49,6 +51,7 @@ class ScheduleComponent extends StatelessWidget {
         _onEndDateTimeChanged = onEndDateTimeChanged,
         _descriptionTextEditingController = descriptionTextEditingController,
         _onDescriptionChanged = onDescriptionChanged,
+        _canSave = canSave,
         _onPressedSave = onPressedSave,
         super(key: key);
 
@@ -67,7 +70,7 @@ class ScheduleComponent extends StatelessWidget {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               child: const Text(ScheduleComponentConstants.save),
-              onPressed: _onPressedSave,
+              onPressed: _getSaveCallback(context),
             ),
           )
         ],
@@ -170,5 +173,16 @@ class ScheduleComponent extends StatelessWidget {
         );
       },
     );
+  }
+
+  VoidCallback? _getSaveCallback(BuildContext context) {
+    if(!_canSave) {
+      return null;
+    }
+
+    return () {
+      _onPressedSave();
+      Navigator.pop(context);
+    };
   }
 }

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -190,6 +190,7 @@ class ScheduleComponent extends StatelessWidget {
     return () {
       _onPressedSave();
       Navigator.pop(context);
+      _onDiscard();
     };
   }
 

--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -5,8 +5,8 @@ import 'package:schedule_management_app/presentation/view/constants/schedule_cre
 import 'package:schedule_management_app/presentation/view/factory/widget_factory.dart';
 
 class ScheduleComponent extends StatelessWidget {
+  final String _appBarText;
   final String _title;
-  final TextEditingController _titleTextEditingController;
   final ValueChanged<String> _onTitleChanged;
   final bool _isWholeDay;
   final ValueChanged<bool> _onWholeDayChanged;
@@ -16,7 +16,7 @@ class ScheduleComponent extends StatelessWidget {
   final String _endDateTimeText;
   final ValueChanged<DateTime> _onStartDateTimeChanged;
   final ValueChanged<DateTime> _onEndDateTimeChanged;
-  final TextEditingController _descriptionTextEditingController;
+  final String _description;
   final ValueChanged<String> _onDescriptionChanged;
   final bool _canSave;
   final bool _isModified;
@@ -26,7 +26,7 @@ class ScheduleComponent extends StatelessWidget {
   const ScheduleComponent({
     final Key? key,
     required final String appBarText,
-    required final TextEditingController titleTextEditingController,
+    required final String title,
     required final ValueChanged<String> onTitleChanged,
     required final bool isWholeDay,
     required final ValueChanged<bool> onWholeDayChanged,
@@ -36,14 +36,14 @@ class ScheduleComponent extends StatelessWidget {
     required final String endDateTimeText,
     required final ValueChanged<DateTime> onStartDateTimeChanged,
     required final ValueChanged<DateTime> onEndDateTimeChanged,
-    required final TextEditingController descriptionTextEditingController,
+    required final String description,
     required final ValueChanged<String> onDescriptionChanged,
     required final bool canSave,
     required final bool isModified,
     required final VoidCallback onPressedSave,
     required final VoidCallback onDiscard,
-  })  : _title = appBarText,
-        _titleTextEditingController = titleTextEditingController,
+  })  : _appBarText = appBarText,
+        _title = title,
         _onTitleChanged = onTitleChanged,
         _isWholeDay = isWholeDay,
         _onWholeDayChanged = onWholeDayChanged,
@@ -53,7 +53,7 @@ class ScheduleComponent extends StatelessWidget {
         _endDateTimeText = endDateTimeText,
         _onStartDateTimeChanged = onStartDateTimeChanged,
         _onEndDateTimeChanged = onEndDateTimeChanged,
-        _descriptionTextEditingController = descriptionTextEditingController,
+        _description = description,
         _onDescriptionChanged = onDescriptionChanged,
         _canSave = canSave,
         _isModified = isModified,
@@ -65,7 +65,7 @@ class ScheduleComponent extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(_title),
+        title: Text(_appBarText),
         centerTitle: true,
         leading: IconButton(
           icon: const Icon(Icons.close),
@@ -85,8 +85,8 @@ class ScheduleComponent extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: [
-            TextField(
-              controller: _titleTextEditingController,
+            TextFormField(
+              initialValue: _title,
               autofocus: true,
               decoration: const InputDecoration(
                 hintText: ScheduleComponentConstants.titleHintText,
@@ -128,8 +128,8 @@ class ScheduleComponent extends StatelessWidget {
               },
             ),
             Expanded(
-              child: TextField(
-                controller: _descriptionTextEditingController,
+              child: TextFormField(
+                initialValue: _description,
                 decoration: const InputDecoration(
                   hintText: ScheduleComponentConstants.descriptionHintText,
                   border: OutlineInputBorder(),

--- a/lib/presentation/view/constants/calendar_constants.dart
+++ b/lib/presentation/view/constants/calendar_constants.dart
@@ -1,5 +1,5 @@
 class CalendarConstants {
-  static DateTime get calendarFirstDay => DateTime.utc(1900, 1, 1);
-  static DateTime get calendarEndDay => DateTime.utc(2100, 12, 31);
+  static DateTime get calendarFirstDay => DateTime(1900, 1, 1);
+  static DateTime get calendarEndDay => DateTime(2100, 12, 31);
   static const String calendarLocale = 'ja';
 }

--- a/lib/presentation/view/constants/schedule_component_constants.dart
+++ b/lib/presentation/view/constants/schedule_component_constants.dart
@@ -5,4 +5,8 @@ class ScheduleComponentConstants {
   static const String end = '終了';
   static const String descriptionHintText = 'コメントを入力してください';
   static const String save = '保存';
+
+  // アクションシート用
+  static const String confirmationDiscard = '編集を破棄';
+  static const String confirmationCancel = 'キャンセル';
 }

--- a/lib/presentation/view/constants/schedule_component_constants.dart
+++ b/lib/presentation/view/constants/schedule_component_constants.dart
@@ -1,0 +1,8 @@
+class ScheduleComponentConstants {
+  static const String titleHintText = 'タイトルを入力してください';
+  static const String wholeDay = '終日';
+  static const String start = '開始';
+  static const String end = '終了';
+  static const String descriptionHintText = 'コメントを入力してください';
+  static const String save = '保存';
+}

--- a/lib/presentation/view/constants/schedule_list_constants.dart
+++ b/lib/presentation/view/constants/schedule_list_constants.dart
@@ -1,3 +1,5 @@
 class ScheduleListConstants {
   static const String scheduleListLocale = 'ja_JP';
+  static const String dateTimeFormat = 'yyyy/MM/dd';
+  static const String dateTimeWeekDayFormat = '(E)';
 }

--- a/lib/presentation/view/constants/text_constants.dart
+++ b/lib/presentation/view/constants/text_constants.dart
@@ -4,12 +4,15 @@ class TextConstants {
   static const String today = '今日';
   static const String calendarDateFormat = 'yyyy年MM月';
 
-  // 予定の追加画面
+  // 予定追加画面
   static const String scheduleCreateViewAppBarTitle = '予定追加';
   static const String wholeDaySwitchOnDateFormat = 'yyyy-MM-dd';
   static const String wholeDaySwitchOffDateFormat = 'yyyy-MM-dd HH:mm';
 
-  // 予定の追加画面(アクションシート用)
+  // 予定編集画面
+  static const String scheduleEditViewAppBarTitle = '予定編集';
+
+  // 予定追加画面(アクションシート用)
   static const String scheduleCreateViewActionSheetDiscardChanges = '編集を破棄';
   static const String scheduleCreateViewActionSheetCancel = 'キャンセル';
 

--- a/lib/presentation/view/constants/text_constants.dart
+++ b/lib/presentation/view/constants/text_constants.dart
@@ -6,14 +6,8 @@ class TextConstants {
 
   // 予定の追加画面
   static const String scheduleCreateViewAppBarTitle = '予定追加';
-  static const String scheduleCreateViewTitleHintText = 'タイトルを入力してください';
-  static const String scheduleCreateViewWholeDay = '終日';
-  static const String scheduleCreateViewStart = '開始';
   static const String wholeDaySwitchOnDateFormat = 'yyyy-MM-dd';
   static const String wholeDaySwitchOffDateFormat = 'yyyy-MM-dd HH:mm';
-  static const String scheduleCreateViewEnd = '終了';
-  static const String scheduleCreateViewCommentHintText = 'コメントを入力してください';
-  static const String scheduleCreateViewSave = '保存';
 
   // 予定の追加画面(アクションシート用)
   static const String scheduleCreateViewActionSheetDiscardChanges = '編集を破棄';
@@ -23,5 +17,4 @@ class TextConstants {
   static const String scheduleListViewDateFormat = 'yyyy/MM/dd (E)';
   static const String scheduleListViewTimeFormat = 'HH:mm';
   static const String scheduleListViewWholeDay = '終日';
-
 }

--- a/lib/presentation/view/constants/text_constants.dart
+++ b/lib/presentation/view/constants/text_constants.dart
@@ -12,10 +12,6 @@ class TextConstants {
   // 予定編集画面
   static const String scheduleEditViewAppBarTitle = '予定編集';
 
-  // 予定追加画面(アクションシート用)
-  static const String scheduleCreateViewActionSheetDiscardChanges = '編集を破棄';
-  static const String scheduleCreateViewActionSheetCancel = 'キャンセル';
-
   // 日別予定一覧画面
   static const String scheduleListViewDateFormat = 'yyyy/MM/dd (E)';
   static const String scheduleListViewTimeFormat = 'HH:mm';

--- a/lib/presentation/view/factory/widget_factory.dart
+++ b/lib/presentation/view/factory/widget_factory.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class WidgetFactory {
+  static Row createDatePickerButton(
+    final BuildContext context,
+    final String title,
+    final String dateTimeText,
+    final VoidCallback? onPressed,
+  ) {
+    return Row(
+      children: [
+        Text(title),
+        TextButton(
+          child: Text(
+            dateTimeText,
+            style: const TextStyle(
+              color: Colors.black,
+            ),
+          ),
+          onPressed: onPressed,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/view/view/calendar_view.dart
+++ b/lib/presentation/view/view/calendar_view.dart
@@ -64,10 +64,9 @@ class CalendarView extends HookConsumerWidget {
                       );
                     },
                     defaultBuilder: (BuildContext context, DateTime day, DateTime focusedDay) {
-                      final date = day.day.toString();
                       return Center(
                         child: Text(
-                          date,
+                          '${day.day}',
                           style: TextStyle(
                             color: _textColor(day),
                           ),

--- a/lib/presentation/view/view/calendar_view.dart
+++ b/lib/presentation/view/view/calendar_view.dart
@@ -30,7 +30,6 @@ class CalendarView extends HookConsumerWidget {
             children: [
               TableCalendar(
                   eventLoader: presenter.getEventsForDay,
-                  locale: CalendarConstants.calendarLocale,
                   firstDay: CalendarConstants.calendarFirstDay,
                   lastDay: CalendarConstants.calendarEndDay,
                   focusedDay: viewModel.focusedDay,

--- a/lib/presentation/view/view/calendar_view.dart
+++ b/lib/presentation/view/view/calendar_view.dart
@@ -29,64 +29,66 @@ class CalendarView extends HookConsumerWidget {
           Stack(
             children: [
               TableCalendar(
-                  eventLoader: presenter.getEventsForDay,
-                  firstDay: CalendarConstants.calendarFirstDay,
-                  lastDay: CalendarConstants.calendarEndDay,
-                  focusedDay: viewModel.focusedDay,
-                  currentDay: viewModel.currentDay,
-                  startingDayOfWeek: StartingDayOfWeek.monday,
-                  daysOfWeekHeight: 20.0,
-                  headerStyle: HeaderStyle(
-                    titleTextFormatter: (date, locale) {
-                      return DateFormat(TextConstants.calendarDateFormat).format(date);
-                    },
-                    titleCentered: true,
-                    formatButtonVisible: false,
-                    leftChevronVisible: false,
-                    rightChevronIcon: const Icon(Icons.arrow_drop_down),
+                eventLoader: presenter.getEventsForDay,
+                firstDay: CalendarConstants.calendarFirstDay,
+                lastDay: CalendarConstants.calendarEndDay,
+                focusedDay: viewModel.focusedDay,
+                currentDay: viewModel.currentDay,
+                startingDayOfWeek: StartingDayOfWeek.monday,
+                daysOfWeekHeight: 20.0,
+                headerStyle: HeaderStyle(
+                  titleTextFormatter: (date, locale) {
+                    return DateFormat(TextConstants.calendarDateFormat).format(date);
+                  },
+                  titleCentered: true,
+                  formatButtonVisible: false,
+                  leftChevronVisible: false,
+                  rightChevronVisible: false,
+                  headerMargin: const EdgeInsets.all(8.0),
+                ),
+                calendarStyle: const CalendarStyle(
+                  todayDecoration: BoxDecoration(
+                    color: Colors.blue,
+                    shape: BoxShape.circle,
                   ),
-                  calendarStyle: const CalendarStyle(
-                    todayDecoration: BoxDecoration(
-                      color: Colors.blue,
-                      shape: BoxShape.circle,
-                    ),
-                  ),
-                  calendarBuilders: CalendarBuilders(
-                    dowBuilder: (BuildContext context, DateTime day) {
-                      final dayOfWeek = DateFormat.E(CalendarConstants.calendarLocale).format(day);
-                      return Center(
-                        child: Text(
-                          dayOfWeek,
-                          style: TextStyle(
-                            color: _textColor(day),
-                          ),
+                ),
+                calendarBuilders: CalendarBuilders(
+                  dowBuilder: (BuildContext context, DateTime day) {
+                    final dayOfWeek = DateFormat.E(CalendarConstants.calendarLocale).format(day);
+                    return Center(
+                      child: Text(
+                        dayOfWeek,
+                        style: TextStyle(
+                          color: _textColor(day),
                         ),
-                      );
-                    },
-                    defaultBuilder: (BuildContext context, DateTime day, DateTime focusedDay) {
-                      return Center(
-                        child: Text(
-                          '${day.day}',
-                          style: TextStyle(
-                            color: _textColor(day),
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                  onHeaderTapped: (_) {
-                    showMonthPicker(context: context, initialDate: viewModel.focusedDay).then(
-                      (date) async {
-                        await presenter.focusMonth(date);
-                      },
+                      ),
                     );
                   },
-                  onDaySelected: (selectedDay, focusedDay) async {
-                    await presenter.showScheduleListView(context, selectedDay);
+                  defaultBuilder: (BuildContext context, DateTime day, DateTime focusedDay) {
+                    return Center(
+                      child: Text(
+                        '${day.day}',
+                        style: TextStyle(
+                          color: _textColor(day),
+                        ),
+                      ),
+                    );
                   },
-                  onPageChanged: (dateTime) async {
-                    await presenter.focusMonth(dateTime);
-                  }),
+                ),
+                onHeaderTapped: (_) {
+                  showMonthPicker(context: context, initialDate: viewModel.focusedDay).then(
+                    (date) async {
+                      await presenter.focusMonth(date);
+                    },
+                  );
+                },
+                onDaySelected: (selectedDay, focusedDay) async {
+                  await presenter.showScheduleListView(context, selectedDay);
+                },
+                onPageChanged: (dateTime) async {
+                  await presenter.focusMonth(dateTime);
+                },
+              ),
               Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: OutlinedButton(

--- a/lib/presentation/view/view/schedule_create_view.dart
+++ b/lib/presentation/view/view/schedule_create_view.dart
@@ -29,7 +29,7 @@ class ScheduleCreateView extends HookConsumerWidget {
       onDescriptionChanged: presenter.setDescription,
       canSave: viewModel.canSave,
       isModified: viewModel.isModified,
-      onPressedSave: () => presenter.save(ref),
+      onPressedSave: () async => await presenter.save(ref),
       onDiscard: () => presenter.refreshState(ref),
     );
   }

--- a/lib/presentation/view/view/schedule_create_view.dart
+++ b/lib/presentation/view/view/schedule_create_view.dart
@@ -15,7 +15,7 @@ class ScheduleCreateView extends HookConsumerWidget {
 
     return ScheduleComponent(
       appBarText: TextConstants.scheduleCreateViewAppBarTitle,
-      titleTextEditingController: TextEditingController(text: viewModel.title),
+      title: viewModel.title,
       onTitleChanged: presenter.setTitle,
       isWholeDay: viewModel.isWholeDay,
       onWholeDayChanged: presenter.setWholeDay,
@@ -25,7 +25,7 @@ class ScheduleCreateView extends HookConsumerWidget {
       endDateTimeText: viewModel.endDateTimeText,
       onStartDateTimeChanged: presenter.setStartDateTime,
       onEndDateTimeChanged: presenter.setEndDateTime,
-      descriptionTextEditingController: TextEditingController(text: viewModel.description),
+      description: viewModel.description,
       onDescriptionChanged: presenter.setDescription,
       canSave: viewModel.canSave,
       isModified: viewModel.isModified,

--- a/lib/presentation/view/view/schedule_create_view.dart
+++ b/lib/presentation/view/view/schedule_create_view.dart
@@ -2,8 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/schedule_create_providers.dart';
+import 'package:schedule_management_app/presentation/view/component/schedule_component.dart';
 import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
-import 'package:schedule_management_app/presentation/view/factory/widget_factory.dart';
 
 class ScheduleCreateView extends HookConsumerWidget {
   const ScheduleCreateView({final Key? key}) : super(key: key);
@@ -13,72 +13,21 @@ class ScheduleCreateView extends HookConsumerWidget {
     final viewModel = ref.watch(scheduleCreateStateProvider);
     final presenter = ref.watch(scheduleCreatePresenterProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text(TextConstants.scheduleCreateViewAppBarTitle),
-        centerTitle: true,
-        leading: IconButton(
-          icon: const Icon(Icons.close),
-          onPressed: () {
-            presenter.closeView(context, ref);
-          },
-        ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: ElevatedButton(
-              child: const Text(TextConstants.scheduleCreateViewSave),
-              onPressed: presenter.getSaveCallback(context, ref),
-            ),
-          ),
-        ],
-      ),
-      body: Column(
-        children: [
-          TextField(
-            autofocus: true,
-            decoration: const InputDecoration(
-              hintText: TextConstants.scheduleCreateViewTitleHintText,
-            ),
-            onChanged: presenter.setTitle,
-          ),
-          Row(
-            children: [
-              const Text(TextConstants.scheduleCreateViewWholeDay),
-              Switch(
-                value: viewModel.isWholeDay,
-                onChanged: presenter.setWholeDay,
-              ),
-            ],
-          ),
-          WidgetFactory.createDatePickerButton(
-            context,
-            TextConstants.scheduleCreateViewStart,
-            viewModel.startDateTimeText,
-            () {
-              presenter.showStartDateTimePicker(context);
-            },
-          ),
-          WidgetFactory.createDatePickerButton(
-            context,
-            TextConstants.scheduleCreateViewEnd,
-            viewModel.endDateTimeText,
-            () {
-              presenter.showEndDateTimePicker(context);
-            },
-          ),
-          Expanded(
-            child: TextField(
-              decoration: const InputDecoration(
-                hintText: TextConstants.scheduleCreateViewCommentHintText,
-              ),
-              keyboardType: TextInputType.multiline,
-              maxLines: null,
-              onChanged: presenter.setDescription,
-            ),
-          ),
-        ],
-      ),
+    return ScheduleComponent(
+      appBarText: TextConstants.scheduleCreateViewAppBarTitle,
+      titleTextEditingController: TextEditingController(text: viewModel.title),
+      onTitleChanged: presenter.setTitle,
+      isWholeDay: viewModel.isWholeDay,
+      onWholeDayChanged: presenter.setWholeDay,
+      startDateTime: viewModel.startDateTime,
+      endDateTime: viewModel.endDateTime,
+      startDateTimeText: viewModel.startDateTimeText,
+      endDateTimeText: viewModel.endDateTimeText,
+      onStartDateTimeChanged: presenter.setStartDateTime,
+      onEndDateTimeChanged: presenter.setEndDateTime,
+      descriptionTextEditingController: TextEditingController(text: viewModel.description),
+      onDescriptionChanged: presenter.setDescription,
+      onPressedSave: presenter.getSaveCallback(context, ref),
     );
   }
 }

--- a/lib/presentation/view/view/schedule_create_view.dart
+++ b/lib/presentation/view/view/schedule_create_view.dart
@@ -28,9 +28,9 @@ class ScheduleCreateView extends HookConsumerWidget {
       descriptionTextEditingController: TextEditingController(text: viewModel.description),
       onDescriptionChanged: presenter.setDescription,
       canSave: viewModel.canSave,
-      onPressedSave: () {
-        return presenter.save(ref);
-      },
+      isModified: viewModel.isModified,
+      onPressedSave: () => presenter.save(ref),
+      onDiscard: () => presenter.refreshState(ref),
     );
   }
 }

--- a/lib/presentation/view/view/schedule_create_view.dart
+++ b/lib/presentation/view/view/schedule_create_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/schedule_create_providers.dart';
 import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
+import 'package:schedule_management_app/presentation/view/factory/widget_factory.dart';
 
 class ScheduleCreateView extends HookConsumerWidget {
   const ScheduleCreateView({final Key? key}) : super(key: key);
@@ -50,7 +51,7 @@ class ScheduleCreateView extends HookConsumerWidget {
               ),
             ],
           ),
-          _buildDatePickerButton(
+          WidgetFactory.createDatePickerButton(
             context,
             TextConstants.scheduleCreateViewStart,
             viewModel.startDateTimeText,
@@ -58,7 +59,7 @@ class ScheduleCreateView extends HookConsumerWidget {
               presenter.showStartDateTimePicker(context);
             },
           ),
-          _buildDatePickerButton(
+          WidgetFactory.createDatePickerButton(
             context,
             TextConstants.scheduleCreateViewEnd,
             viewModel.endDateTimeText,
@@ -78,28 +79,6 @@ class ScheduleCreateView extends HookConsumerWidget {
           ),
         ],
       ),
-    );
-  }
-
-  Row _buildDatePickerButton(
-    final BuildContext context,
-    final String title,
-    final String dateTimeText,
-    final VoidCallback? onPressed,
-  ) {
-    return Row(
-      children: [
-        Text(title),
-        TextButton(
-          child: Text(
-            dateTimeText,
-            style: const TextStyle(
-              color: Colors.black,
-            ),
-          ),
-          onPressed: onPressed,
-        ),
-      ],
     );
   }
 }

--- a/lib/presentation/view/view/schedule_create_view.dart
+++ b/lib/presentation/view/view/schedule_create_view.dart
@@ -27,7 +27,10 @@ class ScheduleCreateView extends HookConsumerWidget {
       onEndDateTimeChanged: presenter.setEndDateTime,
       descriptionTextEditingController: TextEditingController(text: viewModel.description),
       onDescriptionChanged: presenter.setDescription,
-      onPressedSave: presenter.getSaveCallback(context, ref),
+      canSave: viewModel.canSave,
+      onPressedSave: () {
+        return presenter.save(ref);
+      },
     );
   }
 }

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/schedule_edit_providers.dart';
-import 'package:schedule_management_app/presentation/view/factory/widget_factory.dart';
+import 'package:schedule_management_app/presentation/view/component/schedule_component.dart';
 
 class ScheduleEditView extends HookConsumerWidget {
   const ScheduleEditView({Key? key}) : super(key: key);
@@ -10,80 +10,33 @@ class ScheduleEditView extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final viewModel = ref.watch(scheduleEditStateProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('予定編集'),
-        centerTitle: true,
-        leading: IconButton(
-          icon: const Icon(Icons.close),
-          onPressed: () => Navigator.pop(context),
-        ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: ElevatedButton(
-              child: const Text('保存'),
-              onPressed: () {
-                // TODO 保存の処理
-              },
-            ),
-          )
-        ],
-      ),
-      body: Column(
-        children: [
-          TextField(
-            controller: TextEditingController(text: viewModel.title),
-            autofocus: true,
-            decoration: const InputDecoration(
-              hintText: 'タイトルを入力してください',
-            ),
-            onChanged: (_) {
-              // TODO 文字が入力されたときの処理
-            },
-          ),
-          Row(
-            children: [
-              const Text('終日'),
-              Switch(
-                value: viewModel.isWholeDay,
-                onChanged: (_) {
-                  // TODO 終日スイッチの処理
-                },
-              ),
-            ],
-          ),
-          WidgetFactory.createDatePickerButton(
-            context,
-            '開始',
-            viewModel.startDateTimeText,
-            () {
-              // TODO DatePickerを表示する処理
-            },
-          ),
-          WidgetFactory.createDatePickerButton(
-            context,
-            '終了',
-            viewModel.endDateTimeText,
-            () {
-              // TODO DatePickerを表示する処理
-            },
-          ),
-          Expanded(
-            child: TextField(
-              controller: TextEditingController(text: viewModel.description),
-              decoration: const InputDecoration(
-                hintText: 'コメントを入力してください',
-              ),
-              keyboardType: TextInputType.multiline,
-              maxLines: null,
-              onChanged: (_) {
-                // TODO コメントが入力されたときの処理
-              },
-            ),
-          ),
-        ],
-      ),
+    return ScheduleComponent(
+      appBarText: '予定編集',
+      titleTextEditingController: TextEditingController(text: viewModel.title),
+      onTitleChanged: (_) {
+        // TODO 文字が入力されたときの処理
+      },
+      isWholeDay: viewModel.isWholeDay,
+      onWholeDayChanged: (_) {
+        // TODO 終日スイッチの処理
+      },
+      startDateTime: viewModel.startDateTime,
+      endDateTime: viewModel.endDateTime,
+      startDateTimeText: viewModel.startDateTimeText,
+      endDateTimeText: viewModel.endDateTimeText,
+      onStartDateTimeChanged: (_) {
+        // TODO 開始時間ピッカーをタップしたときの処理
+      },
+      onEndDateTimeChanged: (_) {
+        // TODO 終了時間ピッカーをタップしたときの処理
+      },
+      descriptionTextEditingController: TextEditingController(text: viewModel.description),
+      onDescriptionChanged: (_) {
+        // TODO コメントが編集されたときの処理
+      },
+      onPressedSave: () {
+        // TODO 保存の処理
+      },
     );
   }
 }

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -27,8 +27,8 @@ class ScheduleEditView extends HookConsumerWidget {
       descriptionTextEditingController: TextEditingController(text: viewModel.description),
       onDescriptionChanged: presenter.setDescription,
       canSave: viewModel.canSave,
-      onPressedSave: () {
-        return presenter.save(ref);
+      onPressedSave: () async {
+        return await presenter.save(ref);
       },
     );
   }

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:schedule_management_app/domain/provider/schedule_edit_providers.dart';
 import 'package:schedule_management_app/presentation/view/factory/widget_factory.dart';
 
 class ScheduleEditView extends HookConsumerWidget {
@@ -7,6 +8,8 @@ class ScheduleEditView extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.watch(scheduleEditStateProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('予定編集'),
@@ -30,6 +33,7 @@ class ScheduleEditView extends HookConsumerWidget {
       body: Column(
         children: [
           TextField(
+            controller: TextEditingController(text: viewModel.title),
             autofocus: true,
             decoration: const InputDecoration(
               hintText: 'タイトルを入力してください',
@@ -41,7 +45,7 @@ class ScheduleEditView extends HookConsumerWidget {
           WidgetFactory.createDatePickerButton(
             context,
             '開始',
-            DateTime.now().toString(),
+            viewModel.startDateTimeText,
             () {
               // TODO DatePickerを表示する処理
             },
@@ -49,13 +53,14 @@ class ScheduleEditView extends HookConsumerWidget {
           WidgetFactory.createDatePickerButton(
             context,
             '終了',
-            DateTime.now().toString(),
+            viewModel.endDateTimeText,
             () {
               // TODO DatePickerを表示する処理
             },
           ),
           Expanded(
             child: TextField(
+              controller: TextEditingController(text: viewModel.description),
               decoration: const InputDecoration(
                 hintText: 'コメントを入力してください',
               ),

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/schedule_edit_providers.dart';
 import 'package:schedule_management_app/presentation/view/component/schedule_component.dart';
+import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
 
 class ScheduleEditView extends HookConsumerWidget {
   const ScheduleEditView({Key? key}) : super(key: key);
@@ -9,34 +10,25 @@ class ScheduleEditView extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final viewModel = ref.watch(scheduleEditStateProvider);
+    final presenter = ref.watch(scheduleEditPresenterProvider);
 
     return ScheduleComponent(
-      appBarText: '予定編集',
+      appBarText: TextConstants.scheduleEditViewAppBarTitle,
       titleTextEditingController: TextEditingController(text: viewModel.title),
-      onTitleChanged: (_) {
-        // TODO 文字が入力されたときの処理
-      },
+      onTitleChanged: presenter.setTitle,
       isWholeDay: viewModel.isWholeDay,
-      onWholeDayChanged: (_) {
-        // TODO 終日スイッチの処理
-      },
+      onWholeDayChanged: presenter.setWholeDay,
       startDateTime: viewModel.startDateTime,
       endDateTime: viewModel.endDateTime,
       startDateTimeText: viewModel.startDateTimeText,
       endDateTimeText: viewModel.endDateTimeText,
-      onStartDateTimeChanged: (_) {
-        // TODO 開始時間ピッカーをタップしたときの処理
-      },
-      onEndDateTimeChanged: (_) {
-        // TODO 終了時間ピッカーをタップしたときの処理
-      },
+      onStartDateTimeChanged: presenter.setStartDateTime,
+      onEndDateTimeChanged: presenter.setEndDateTime,
       descriptionTextEditingController: TextEditingController(text: viewModel.description),
-      onDescriptionChanged: (_) {
-        // TODO コメントが編集されたときの処理
-      },
+      onDescriptionChanged: presenter.setDescription,
       canSave: viewModel.canSave,
       onPressedSave: () {
-        // TODO 保存の処理
+        return presenter.save(ref);
       },
     );
   }

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:schedule_management_app/presentation/view/factory/widget_factory.dart';
+
+class ScheduleEditView extends HookConsumerWidget {
+  const ScheduleEditView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('予定編集'),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              child: const Text('保存'),
+              onPressed: () {
+                // TODO 保存の処理
+              },
+            ),
+          )
+        ],
+      ),
+      body: Column(
+        children: [
+          TextField(
+            autofocus: true,
+            decoration: const InputDecoration(
+              hintText: 'タイトルを入力してください',
+            ),
+            onChanged: (_) {
+              // TODO 文字が入力されたときの処理
+            },
+          ),
+          WidgetFactory.createDatePickerButton(
+            context,
+            '開始',
+            DateTime.now().toString(),
+            () {
+              // TODO DatePickerを表示する処理
+            },
+          ),
+          WidgetFactory.createDatePickerButton(
+            context,
+            '終了',
+            DateTime.now().toString(),
+            () {
+              // TODO DatePickerを表示する処理
+            },
+          ),
+          Expanded(
+            child: TextField(
+              decoration: const InputDecoration(
+                hintText: 'コメントを入力してください',
+              ),
+              keyboardType: TextInputType.multiline,
+              maxLines: null,
+              onChanged: (_) {
+                // TODO コメントが入力されたときの処理
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -27,9 +27,9 @@ class ScheduleEditView extends HookConsumerWidget {
       descriptionTextEditingController: TextEditingController(text: viewModel.description),
       onDescriptionChanged: presenter.setDescription,
       canSave: viewModel.canSave,
-      onPressedSave: () async {
-        return await presenter.save(ref);
-      },
+      isModified: viewModel.isModified,
+      onPressedSave: () async => await presenter.save(ref),
+      onDiscard: () => presenter.refreshState(ref),
     );
   }
 }

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -34,6 +34,7 @@ class ScheduleEditView extends HookConsumerWidget {
       onDescriptionChanged: (_) {
         // TODO コメントが編集されたときの処理
       },
+      canSave: viewModel.canSave,
       onPressedSave: () {
         // TODO 保存の処理
       },

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -14,7 +14,7 @@ class ScheduleEditView extends HookConsumerWidget {
 
     return ScheduleComponent(
       appBarText: TextConstants.scheduleEditViewAppBarTitle,
-      titleTextEditingController: TextEditingController(text: viewModel.title),
+      title: viewModel.title,
       onTitleChanged: presenter.setTitle,
       isWholeDay: viewModel.isWholeDay,
       onWholeDayChanged: presenter.setWholeDay,
@@ -24,7 +24,7 @@ class ScheduleEditView extends HookConsumerWidget {
       endDateTimeText: viewModel.endDateTimeText,
       onStartDateTimeChanged: presenter.setStartDateTime,
       onEndDateTimeChanged: presenter.setEndDateTime,
-      descriptionTextEditingController: TextEditingController(text: viewModel.description),
+      description: viewModel.description,
       onDescriptionChanged: presenter.setDescription,
       canSave: viewModel.canSave,
       isModified: viewModel.isModified,

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -42,6 +42,17 @@ class ScheduleEditView extends HookConsumerWidget {
               // TODO 文字が入力されたときの処理
             },
           ),
+          Row(
+            children: [
+              const Text('終日'),
+              Switch(
+                value: viewModel.isWholeDay,
+                onChanged: (_) {
+                  // TODO 終日スイッチの処理
+                },
+              ),
+            ],
+          ),
           WidgetFactory.createDatePickerButton(
             context,
             '開始',

--- a/lib/presentation/view/view/schedule_list_view.dart
+++ b/lib/presentation/view/view/schedule_list_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schedule_management_app/domain/provider/schedule_list_providers.dart';
@@ -69,7 +70,7 @@ class ScheduleListView extends HookConsumerWidget {
                 Container(
                   height: 50.0,
                   width: 5.0,
-                  color: Colors.blue,
+                  color: viewModel.scheduleElements[index].isWholeDay ?  Colors.redAccent : Colors.blue,
                 ),
                 Expanded(
                   child: Align(

--- a/lib/presentation/view/view/schedule_list_view.dart
+++ b/lib/presentation/view/view/schedule_list_view.dart
@@ -1,10 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:schedule_management_app/domain/provider/schedule_list_providers.dart';
-import 'package:schedule_management_app/presentation/view/constants/schedule_list_constants.dart';
-import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
-import 'package:schedule_management_app/presentation/view/view/schedule_edit_view.dart';
 
 class ScheduleListView extends HookConsumerWidget {
   const ScheduleListView({final Key? key}) : super(key: key);
@@ -14,7 +10,14 @@ class ScheduleListView extends HookConsumerWidget {
     final viewModel = ref.watch(scheduleListStateProvider);
     final presenter = ref.watch(scheduleListPresenterProvider);
 
-    return SimpleDialog(
+    return AlertDialog(
+      insetPadding: const EdgeInsets.all(24.0),
+      contentPadding: const EdgeInsets.all(16.0),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(
+          Radius.circular(20.0),
+        ),
+      ),
       title: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -45,36 +48,50 @@ class ScheduleListView extends HookConsumerWidget {
           ),
         ],
       ),
-      children: [
-        Column(
-          children: [
-            for (var i = 0; i < viewModel.scheduleElements.length; ++i) ...{
-              Row(
-                children: [
-                  Column(
-                    children: [
-                      for (var j = 0;
-                          j < viewModel.scheduleElements[i].dateTimeTexts.length;
-                          ++j) ...{
-                        Text(viewModel.scheduleElements[i].dateTimeTexts[j]),
-                      }
-                    ],
+      content: SizedBox(
+        height: MediaQuery.of(context).size.height / 2.0,
+        width: MediaQuery.of(context).size.width - 24.0,
+        child: ListView.builder(
+          itemCount: viewModel.scheduleElements.length,
+          itemBuilder: (BuildContext context, int index) {
+            return Row(
+              children: [
+                Column(
+                  children: [
+                    for (var i = 0;
+                        i < viewModel.scheduleElements[index].dateTimeTexts.length;
+                        ++i) ...{
+                      Text(viewModel.scheduleElements[index].dateTimeTexts[i]),
+                    }
+                  ],
+                ),
+                const SizedBox(width: 8.0),
+                Container(
+                  height: 50.0,
+                  width: 5.0,
+                  color: Colors.blue,
+                ),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton(
+                      child: Text(
+                        viewModel.scheduleElements[index].scheduleTitle,
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                      ),
+                      onPressed: () {
+                        presenter.showScheduleEditView(
+                            context,
+                            viewModel.scheduleElements[index].scheduleId,
+                            viewModel.selectedDateTime);
+                      },
+                    ),
                   ),
-                  TextButton(
-                    child: Text(viewModel.scheduleElements[i].scheduleTitle),
-                    onPressed: () {
-                      presenter.showScheduleEditView(context, viewModel.scheduleElements[i].scheduleId);
-                    },
-                  ),
-                ],
-              ),
-            }
-          ],
-        ),
-      ],
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(
-          Radius.circular(20.0),
+                ),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/lib/presentation/view/view/schedule_list_view.dart
+++ b/lib/presentation/view/view/schedule_list_view.dart
@@ -21,7 +21,7 @@ class ScheduleListView extends HookConsumerWidget {
             DateFormat(
               TextConstants.scheduleListViewDateFormat,
               ScheduleListConstants.scheduleListLocale,
-            ).format(viewModel.selectedDay),
+            ).format(viewModel.selectedDateTime),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
@@ -31,7 +31,7 @@ class ScheduleListView extends HookConsumerWidget {
               color: Colors.blue,
             ),
             onPressed: () {
-              presenter.showScheduleCreateView(context, viewModel.selectedDay);
+              presenter.showScheduleCreateView(context, viewModel.selectedDateTime);
             },
           ),
         ],

--- a/lib/presentation/view/view/schedule_list_view.dart
+++ b/lib/presentation/view/view/schedule_list_view.dart
@@ -63,13 +63,7 @@ class ScheduleListView extends HookConsumerWidget {
                   TextButton(
                     child: Text(viewModel.scheduleElements[i].scheduleTitle),
                     onPressed: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (BuildContext context) {
-                            return const ScheduleEditView();
-                          },
-                        ),
-                      );
+                      presenter.showScheduleEditView(context, viewModel.scheduleElements[i].scheduleId);
                     },
                   ),
                 ],

--- a/lib/presentation/view/view/schedule_list_view.dart
+++ b/lib/presentation/view/view/schedule_list_view.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:schedule_management_app/domain/provider/schedule_list_providers.dart';
 import 'package:schedule_management_app/presentation/view/constants/schedule_list_constants.dart';
 import 'package:schedule_management_app/presentation/view/constants/text_constants.dart';
+import 'package:schedule_management_app/presentation/view/view/schedule_edit_view.dart';
 
 class ScheduleListView extends HookConsumerWidget {
   const ScheduleListView({final Key? key}) : super(key: key);
@@ -59,7 +60,18 @@ class ScheduleListView extends HookConsumerWidget {
                       }
                     ],
                   ),
-                  Text(viewModel.scheduleElements[i].scheduleTitle),
+                  TextButton(
+                    child: Text(viewModel.scheduleElements[i].scheduleTitle),
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (BuildContext context) {
+                            return const ScheduleEditView();
+                          },
+                        ),
+                      );
+                    },
+                  ),
                 ],
               ),
             }

--- a/lib/presentation/view/view/schedule_list_view.dart
+++ b/lib/presentation/view/view/schedule_list_view.dart
@@ -17,11 +17,19 @@ class ScheduleListView extends HookConsumerWidget {
       title: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            DateFormat(
-              TextConstants.scheduleListViewDateFormat,
-              ScheduleListConstants.scheduleListLocale,
-            ).format(viewModel.selectedDateTime),
+          RichText(
+            text: TextSpan(
+              style: Theme.of(context).textTheme.headline6,
+              children: [
+                TextSpan(
+                  text: viewModel.selectedDateTimeText,
+                ),
+                TextSpan(
+                  text: viewModel.weekDayText,
+                  style: TextStyle(color: viewModel.weekDayColor),
+                ),
+              ],
+            ),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
@@ -44,7 +52,9 @@ class ScheduleListView extends HookConsumerWidget {
                 children: [
                   Column(
                     children: [
-                      for (var j = 0; j < viewModel.scheduleElements[i].dateTimeTexts.length; ++j) ...{
+                      for (var j = 0;
+                          j < viewModel.scheduleElements[i].dateTimeTexts.length;
+                          ++j) ...{
                         Text(viewModel.scheduleElements[i].dateTimeTexts[j]),
                       }
                     ],

--- a/lib/presentation/view/view_model/schedule_create_view_model.dart
+++ b/lib/presentation/view/view_model/schedule_create_view_model.dart
@@ -6,7 +6,7 @@ part 'schedule_create_view_model.freezed.dart';
 abstract class ScheduleCreateViewModel with _$ScheduleCreateViewModel {
   const factory ScheduleCreateViewModel({
     required final int maximumYear,
-    required final DateTime selectedDay,
+    required final DateTime selectedDateTime,
     required final String title,
     required final bool isWholeDay,
     required final DateTime startDateTime,

--- a/lib/presentation/view/view_model/schedule_create_view_model.freezed.dart
+++ b/lib/presentation/view/view_model/schedule_create_view_model.freezed.dart
@@ -17,7 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$ScheduleCreateViewModel {
   int get maximumYear => throw _privateConstructorUsedError;
-  DateTime get selectedDay => throw _privateConstructorUsedError;
+  DateTime get selectedDateTime => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
   bool get isWholeDay => throw _privateConstructorUsedError;
   DateTime get startDateTime => throw _privateConstructorUsedError;
@@ -40,7 +40,7 @@ abstract class $ScheduleCreateViewModelCopyWith<$Res> {
       _$ScheduleCreateViewModelCopyWithImpl<$Res>;
   $Res call(
       {int maximumYear,
-      DateTime selectedDay,
+      DateTime selectedDateTime,
       String title,
       bool isWholeDay,
       DateTime startDateTime,
@@ -64,7 +64,7 @@ class _$ScheduleCreateViewModelCopyWithImpl<$Res>
   @override
   $Res call({
     Object? maximumYear = freezed,
-    Object? selectedDay = freezed,
+    Object? selectedDateTime = freezed,
     Object? title = freezed,
     Object? isWholeDay = freezed,
     Object? startDateTime = freezed,
@@ -80,9 +80,9 @@ class _$ScheduleCreateViewModelCopyWithImpl<$Res>
           ? _value.maximumYear
           : maximumYear // ignore: cast_nullable_to_non_nullable
               as int,
-      selectedDay: selectedDay == freezed
-          ? _value.selectedDay
-          : selectedDay // ignore: cast_nullable_to_non_nullable
+      selectedDateTime: selectedDateTime == freezed
+          ? _value.selectedDateTime
+          : selectedDateTime // ignore: cast_nullable_to_non_nullable
               as DateTime,
       title: title == freezed
           ? _value.title
@@ -133,7 +133,7 @@ abstract class _$ScheduleCreateViewModelCopyWith<$Res>
   @override
   $Res call(
       {int maximumYear,
-      DateTime selectedDay,
+      DateTime selectedDateTime,
       String title,
       bool isWholeDay,
       DateTime startDateTime,
@@ -160,7 +160,7 @@ class __$ScheduleCreateViewModelCopyWithImpl<$Res>
   @override
   $Res call({
     Object? maximumYear = freezed,
-    Object? selectedDay = freezed,
+    Object? selectedDateTime = freezed,
     Object? title = freezed,
     Object? isWholeDay = freezed,
     Object? startDateTime = freezed,
@@ -176,9 +176,9 @@ class __$ScheduleCreateViewModelCopyWithImpl<$Res>
           ? _value.maximumYear
           : maximumYear // ignore: cast_nullable_to_non_nullable
               as int,
-      selectedDay: selectedDay == freezed
-          ? _value.selectedDay
-          : selectedDay // ignore: cast_nullable_to_non_nullable
+      selectedDateTime: selectedDateTime == freezed
+          ? _value.selectedDateTime
+          : selectedDateTime // ignore: cast_nullable_to_non_nullable
               as DateTime,
       title: title == freezed
           ? _value.title
@@ -225,7 +225,7 @@ class __$ScheduleCreateViewModelCopyWithImpl<$Res>
 class _$_ScheduleCreateViewModel implements _ScheduleCreateViewModel {
   const _$_ScheduleCreateViewModel(
       {required this.maximumYear,
-      required this.selectedDay,
+      required this.selectedDateTime,
       required this.title,
       required this.isWholeDay,
       required this.startDateTime,
@@ -239,7 +239,7 @@ class _$_ScheduleCreateViewModel implements _ScheduleCreateViewModel {
   @override
   final int maximumYear;
   @override
-  final DateTime selectedDay;
+  final DateTime selectedDateTime;
   @override
   final String title;
   @override
@@ -261,7 +261,7 @@ class _$_ScheduleCreateViewModel implements _ScheduleCreateViewModel {
 
   @override
   String toString() {
-    return 'ScheduleCreateViewModel(maximumYear: $maximumYear, selectedDay: $selectedDay, title: $title, isWholeDay: $isWholeDay, startDateTime: $startDateTime, endDateTime: $endDateTime, startDateTimeText: $startDateTimeText, endDateTimeText: $endDateTimeText, description: $description, canSave: $canSave, isModified: $isModified)';
+    return 'ScheduleCreateViewModel(maximumYear: $maximumYear, selectedDateTime: $selectedDateTime, title: $title, isWholeDay: $isWholeDay, startDateTime: $startDateTime, endDateTime: $endDateTime, startDateTimeText: $startDateTimeText, endDateTimeText: $endDateTimeText, description: $description, canSave: $canSave, isModified: $isModified)';
   }
 
   @override
@@ -272,7 +272,7 @@ class _$_ScheduleCreateViewModel implements _ScheduleCreateViewModel {
             const DeepCollectionEquality()
                 .equals(other.maximumYear, maximumYear) &&
             const DeepCollectionEquality()
-                .equals(other.selectedDay, selectedDay) &&
+                .equals(other.selectedDateTime, selectedDateTime) &&
             const DeepCollectionEquality().equals(other.title, title) &&
             const DeepCollectionEquality()
                 .equals(other.isWholeDay, isWholeDay) &&
@@ -295,7 +295,7 @@ class _$_ScheduleCreateViewModel implements _ScheduleCreateViewModel {
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(maximumYear),
-      const DeepCollectionEquality().hash(selectedDay),
+      const DeepCollectionEquality().hash(selectedDateTime),
       const DeepCollectionEquality().hash(title),
       const DeepCollectionEquality().hash(isWholeDay),
       const DeepCollectionEquality().hash(startDateTime),
@@ -316,7 +316,7 @@ class _$_ScheduleCreateViewModel implements _ScheduleCreateViewModel {
 abstract class _ScheduleCreateViewModel implements ScheduleCreateViewModel {
   const factory _ScheduleCreateViewModel(
       {required final int maximumYear,
-      required final DateTime selectedDay,
+      required final DateTime selectedDateTime,
       required final String title,
       required final bool isWholeDay,
       required final DateTime startDateTime,
@@ -330,7 +330,7 @@ abstract class _ScheduleCreateViewModel implements ScheduleCreateViewModel {
   @override
   int get maximumYear => throw _privateConstructorUsedError;
   @override
-  DateTime get selectedDay => throw _privateConstructorUsedError;
+  DateTime get selectedDateTime => throw _privateConstructorUsedError;
   @override
   String get title => throw _privateConstructorUsedError;
   @override

--- a/lib/presentation/view/view_model/schedule_edit_view_model.dart
+++ b/lib/presentation/view/view_model/schedule_edit_view_model.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'schedule_edit_view_model.freezed.dart';
+
+@freezed
+abstract class ScheduleEditViewModel with _$ScheduleEditViewModel {
+  const factory ScheduleEditViewModel({
+    required final int maximumYear,
+    required final String title,
+    required final bool isWholeDay,
+    required final DateTime startDateTime,
+    required final DateTime endDateTime,
+    required final String startDateTimeText,
+    required final String endDateTimeText,
+    required final String description,
+    required final bool canSave,
+    required final bool isModified,
+  }) = _ScheduleEditViewModel;
+}

--- a/lib/presentation/view/view_model/schedule_edit_view_model.dart
+++ b/lib/presentation/view/view_model/schedule_edit_view_model.dart
@@ -5,6 +5,7 @@ part 'schedule_edit_view_model.freezed.dart';
 @freezed
 abstract class ScheduleEditViewModel with _$ScheduleEditViewModel {
   const factory ScheduleEditViewModel({
+    required final int scheduleId,
     required final int maximumYear,
     required final String title,
     required final bool isWholeDay,

--- a/lib/presentation/view/view_model/schedule_edit_view_model.freezed.dart
+++ b/lib/presentation/view/view_model/schedule_edit_view_model.freezed.dart
@@ -16,6 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$ScheduleEditViewModel {
+  int get scheduleId => throw _privateConstructorUsedError;
   int get maximumYear => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
   bool get isWholeDay => throw _privateConstructorUsedError;
@@ -38,7 +39,8 @@ abstract class $ScheduleEditViewModelCopyWith<$Res> {
           $Res Function(ScheduleEditViewModel) then) =
       _$ScheduleEditViewModelCopyWithImpl<$Res>;
   $Res call(
-      {int maximumYear,
+      {int scheduleId,
+      int maximumYear,
       String title,
       bool isWholeDay,
       DateTime startDateTime,
@@ -61,6 +63,7 @@ class _$ScheduleEditViewModelCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? scheduleId = freezed,
     Object? maximumYear = freezed,
     Object? title = freezed,
     Object? isWholeDay = freezed,
@@ -73,6 +76,10 @@ class _$ScheduleEditViewModelCopyWithImpl<$Res>
     Object? isModified = freezed,
   }) {
     return _then(_value.copyWith(
+      scheduleId: scheduleId == freezed
+          ? _value.scheduleId
+          : scheduleId // ignore: cast_nullable_to_non_nullable
+              as int,
       maximumYear: maximumYear == freezed
           ? _value.maximumYear
           : maximumYear // ignore: cast_nullable_to_non_nullable
@@ -125,7 +132,8 @@ abstract class _$ScheduleEditViewModelCopyWith<$Res>
       __$ScheduleEditViewModelCopyWithImpl<$Res>;
   @override
   $Res call(
-      {int maximumYear,
+      {int scheduleId,
+      int maximumYear,
       String title,
       bool isWholeDay,
       DateTime startDateTime,
@@ -150,6 +158,7 @@ class __$ScheduleEditViewModelCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? scheduleId = freezed,
     Object? maximumYear = freezed,
     Object? title = freezed,
     Object? isWholeDay = freezed,
@@ -162,6 +171,10 @@ class __$ScheduleEditViewModelCopyWithImpl<$Res>
     Object? isModified = freezed,
   }) {
     return _then(_ScheduleEditViewModel(
+      scheduleId: scheduleId == freezed
+          ? _value.scheduleId
+          : scheduleId // ignore: cast_nullable_to_non_nullable
+              as int,
       maximumYear: maximumYear == freezed
           ? _value.maximumYear
           : maximumYear // ignore: cast_nullable_to_non_nullable
@@ -210,7 +223,8 @@ class __$ScheduleEditViewModelCopyWithImpl<$Res>
 
 class _$_ScheduleEditViewModel implements _ScheduleEditViewModel {
   const _$_ScheduleEditViewModel(
-      {required this.maximumYear,
+      {required this.scheduleId,
+      required this.maximumYear,
       required this.title,
       required this.isWholeDay,
       required this.startDateTime,
@@ -221,6 +235,8 @@ class _$_ScheduleEditViewModel implements _ScheduleEditViewModel {
       required this.canSave,
       required this.isModified});
 
+  @override
+  final int scheduleId;
   @override
   final int maximumYear;
   @override
@@ -244,7 +260,7 @@ class _$_ScheduleEditViewModel implements _ScheduleEditViewModel {
 
   @override
   String toString() {
-    return 'ScheduleEditViewModel(maximumYear: $maximumYear, title: $title, isWholeDay: $isWholeDay, startDateTime: $startDateTime, endDateTime: $endDateTime, startDateTimeText: $startDateTimeText, endDateTimeText: $endDateTimeText, description: $description, canSave: $canSave, isModified: $isModified)';
+    return 'ScheduleEditViewModel(scheduleId: $scheduleId, maximumYear: $maximumYear, title: $title, isWholeDay: $isWholeDay, startDateTime: $startDateTime, endDateTime: $endDateTime, startDateTimeText: $startDateTimeText, endDateTimeText: $endDateTimeText, description: $description, canSave: $canSave, isModified: $isModified)';
   }
 
   @override
@@ -252,6 +268,8 @@ class _$_ScheduleEditViewModel implements _ScheduleEditViewModel {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _ScheduleEditViewModel &&
+            const DeepCollectionEquality()
+                .equals(other.scheduleId, scheduleId) &&
             const DeepCollectionEquality()
                 .equals(other.maximumYear, maximumYear) &&
             const DeepCollectionEquality().equals(other.title, title) &&
@@ -275,6 +293,7 @@ class _$_ScheduleEditViewModel implements _ScheduleEditViewModel {
   @override
   int get hashCode => Object.hash(
       runtimeType,
+      const DeepCollectionEquality().hash(scheduleId),
       const DeepCollectionEquality().hash(maximumYear),
       const DeepCollectionEquality().hash(title),
       const DeepCollectionEquality().hash(isWholeDay),
@@ -295,7 +314,8 @@ class _$_ScheduleEditViewModel implements _ScheduleEditViewModel {
 
 abstract class _ScheduleEditViewModel implements ScheduleEditViewModel {
   const factory _ScheduleEditViewModel(
-      {required final int maximumYear,
+      {required final int scheduleId,
+      required final int maximumYear,
       required final String title,
       required final bool isWholeDay,
       required final DateTime startDateTime,
@@ -306,6 +326,8 @@ abstract class _ScheduleEditViewModel implements ScheduleEditViewModel {
       required final bool canSave,
       required final bool isModified}) = _$_ScheduleEditViewModel;
 
+  @override
+  int get scheduleId => throw _privateConstructorUsedError;
   @override
   int get maximumYear => throw _privateConstructorUsedError;
   @override

--- a/lib/presentation/view/view_model/schedule_edit_view_model.freezed.dart
+++ b/lib/presentation/view/view_model/schedule_edit_view_model.freezed.dart
@@ -1,0 +1,333 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'schedule_edit_view_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ScheduleEditViewModel {
+  int get maximumYear => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  bool get isWholeDay => throw _privateConstructorUsedError;
+  DateTime get startDateTime => throw _privateConstructorUsedError;
+  DateTime get endDateTime => throw _privateConstructorUsedError;
+  String get startDateTimeText => throw _privateConstructorUsedError;
+  String get endDateTimeText => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+  bool get canSave => throw _privateConstructorUsedError;
+  bool get isModified => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ScheduleEditViewModelCopyWith<ScheduleEditViewModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ScheduleEditViewModelCopyWith<$Res> {
+  factory $ScheduleEditViewModelCopyWith(ScheduleEditViewModel value,
+          $Res Function(ScheduleEditViewModel) then) =
+      _$ScheduleEditViewModelCopyWithImpl<$Res>;
+  $Res call(
+      {int maximumYear,
+      String title,
+      bool isWholeDay,
+      DateTime startDateTime,
+      DateTime endDateTime,
+      String startDateTimeText,
+      String endDateTimeText,
+      String description,
+      bool canSave,
+      bool isModified});
+}
+
+/// @nodoc
+class _$ScheduleEditViewModelCopyWithImpl<$Res>
+    implements $ScheduleEditViewModelCopyWith<$Res> {
+  _$ScheduleEditViewModelCopyWithImpl(this._value, this._then);
+
+  final ScheduleEditViewModel _value;
+  // ignore: unused_field
+  final $Res Function(ScheduleEditViewModel) _then;
+
+  @override
+  $Res call({
+    Object? maximumYear = freezed,
+    Object? title = freezed,
+    Object? isWholeDay = freezed,
+    Object? startDateTime = freezed,
+    Object? endDateTime = freezed,
+    Object? startDateTimeText = freezed,
+    Object? endDateTimeText = freezed,
+    Object? description = freezed,
+    Object? canSave = freezed,
+    Object? isModified = freezed,
+  }) {
+    return _then(_value.copyWith(
+      maximumYear: maximumYear == freezed
+          ? _value.maximumYear
+          : maximumYear // ignore: cast_nullable_to_non_nullable
+              as int,
+      title: title == freezed
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      isWholeDay: isWholeDay == freezed
+          ? _value.isWholeDay
+          : isWholeDay // ignore: cast_nullable_to_non_nullable
+              as bool,
+      startDateTime: startDateTime == freezed
+          ? _value.startDateTime
+          : startDateTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endDateTime: endDateTime == freezed
+          ? _value.endDateTime
+          : endDateTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      startDateTimeText: startDateTimeText == freezed
+          ? _value.startDateTimeText
+          : startDateTimeText // ignore: cast_nullable_to_non_nullable
+              as String,
+      endDateTimeText: endDateTimeText == freezed
+          ? _value.endDateTimeText
+          : endDateTimeText // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: description == freezed
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      canSave: canSave == freezed
+          ? _value.canSave
+          : canSave // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isModified: isModified == freezed
+          ? _value.isModified
+          : isModified // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$ScheduleEditViewModelCopyWith<$Res>
+    implements $ScheduleEditViewModelCopyWith<$Res> {
+  factory _$ScheduleEditViewModelCopyWith(_ScheduleEditViewModel value,
+          $Res Function(_ScheduleEditViewModel) then) =
+      __$ScheduleEditViewModelCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {int maximumYear,
+      String title,
+      bool isWholeDay,
+      DateTime startDateTime,
+      DateTime endDateTime,
+      String startDateTimeText,
+      String endDateTimeText,
+      String description,
+      bool canSave,
+      bool isModified});
+}
+
+/// @nodoc
+class __$ScheduleEditViewModelCopyWithImpl<$Res>
+    extends _$ScheduleEditViewModelCopyWithImpl<$Res>
+    implements _$ScheduleEditViewModelCopyWith<$Res> {
+  __$ScheduleEditViewModelCopyWithImpl(_ScheduleEditViewModel _value,
+      $Res Function(_ScheduleEditViewModel) _then)
+      : super(_value, (v) => _then(v as _ScheduleEditViewModel));
+
+  @override
+  _ScheduleEditViewModel get _value => super._value as _ScheduleEditViewModel;
+
+  @override
+  $Res call({
+    Object? maximumYear = freezed,
+    Object? title = freezed,
+    Object? isWholeDay = freezed,
+    Object? startDateTime = freezed,
+    Object? endDateTime = freezed,
+    Object? startDateTimeText = freezed,
+    Object? endDateTimeText = freezed,
+    Object? description = freezed,
+    Object? canSave = freezed,
+    Object? isModified = freezed,
+  }) {
+    return _then(_ScheduleEditViewModel(
+      maximumYear: maximumYear == freezed
+          ? _value.maximumYear
+          : maximumYear // ignore: cast_nullable_to_non_nullable
+              as int,
+      title: title == freezed
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      isWholeDay: isWholeDay == freezed
+          ? _value.isWholeDay
+          : isWholeDay // ignore: cast_nullable_to_non_nullable
+              as bool,
+      startDateTime: startDateTime == freezed
+          ? _value.startDateTime
+          : startDateTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endDateTime: endDateTime == freezed
+          ? _value.endDateTime
+          : endDateTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      startDateTimeText: startDateTimeText == freezed
+          ? _value.startDateTimeText
+          : startDateTimeText // ignore: cast_nullable_to_non_nullable
+              as String,
+      endDateTimeText: endDateTimeText == freezed
+          ? _value.endDateTimeText
+          : endDateTimeText // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: description == freezed
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      canSave: canSave == freezed
+          ? _value.canSave
+          : canSave // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isModified: isModified == freezed
+          ? _value.isModified
+          : isModified // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_ScheduleEditViewModel implements _ScheduleEditViewModel {
+  const _$_ScheduleEditViewModel(
+      {required this.maximumYear,
+      required this.title,
+      required this.isWholeDay,
+      required this.startDateTime,
+      required this.endDateTime,
+      required this.startDateTimeText,
+      required this.endDateTimeText,
+      required this.description,
+      required this.canSave,
+      required this.isModified});
+
+  @override
+  final int maximumYear;
+  @override
+  final String title;
+  @override
+  final bool isWholeDay;
+  @override
+  final DateTime startDateTime;
+  @override
+  final DateTime endDateTime;
+  @override
+  final String startDateTimeText;
+  @override
+  final String endDateTimeText;
+  @override
+  final String description;
+  @override
+  final bool canSave;
+  @override
+  final bool isModified;
+
+  @override
+  String toString() {
+    return 'ScheduleEditViewModel(maximumYear: $maximumYear, title: $title, isWholeDay: $isWholeDay, startDateTime: $startDateTime, endDateTime: $endDateTime, startDateTimeText: $startDateTimeText, endDateTimeText: $endDateTimeText, description: $description, canSave: $canSave, isModified: $isModified)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ScheduleEditViewModel &&
+            const DeepCollectionEquality()
+                .equals(other.maximumYear, maximumYear) &&
+            const DeepCollectionEquality().equals(other.title, title) &&
+            const DeepCollectionEquality()
+                .equals(other.isWholeDay, isWholeDay) &&
+            const DeepCollectionEquality()
+                .equals(other.startDateTime, startDateTime) &&
+            const DeepCollectionEquality()
+                .equals(other.endDateTime, endDateTime) &&
+            const DeepCollectionEquality()
+                .equals(other.startDateTimeText, startDateTimeText) &&
+            const DeepCollectionEquality()
+                .equals(other.endDateTimeText, endDateTimeText) &&
+            const DeepCollectionEquality()
+                .equals(other.description, description) &&
+            const DeepCollectionEquality().equals(other.canSave, canSave) &&
+            const DeepCollectionEquality()
+                .equals(other.isModified, isModified));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(maximumYear),
+      const DeepCollectionEquality().hash(title),
+      const DeepCollectionEquality().hash(isWholeDay),
+      const DeepCollectionEquality().hash(startDateTime),
+      const DeepCollectionEquality().hash(endDateTime),
+      const DeepCollectionEquality().hash(startDateTimeText),
+      const DeepCollectionEquality().hash(endDateTimeText),
+      const DeepCollectionEquality().hash(description),
+      const DeepCollectionEquality().hash(canSave),
+      const DeepCollectionEquality().hash(isModified));
+
+  @JsonKey(ignore: true)
+  @override
+  _$ScheduleEditViewModelCopyWith<_ScheduleEditViewModel> get copyWith =>
+      __$ScheduleEditViewModelCopyWithImpl<_ScheduleEditViewModel>(
+          this, _$identity);
+}
+
+abstract class _ScheduleEditViewModel implements ScheduleEditViewModel {
+  const factory _ScheduleEditViewModel(
+      {required final int maximumYear,
+      required final String title,
+      required final bool isWholeDay,
+      required final DateTime startDateTime,
+      required final DateTime endDateTime,
+      required final String startDateTimeText,
+      required final String endDateTimeText,
+      required final String description,
+      required final bool canSave,
+      required final bool isModified}) = _$_ScheduleEditViewModel;
+
+  @override
+  int get maximumYear => throw _privateConstructorUsedError;
+  @override
+  String get title => throw _privateConstructorUsedError;
+  @override
+  bool get isWholeDay => throw _privateConstructorUsedError;
+  @override
+  DateTime get startDateTime => throw _privateConstructorUsedError;
+  @override
+  DateTime get endDateTime => throw _privateConstructorUsedError;
+  @override
+  String get startDateTimeText => throw _privateConstructorUsedError;
+  @override
+  String get endDateTimeText => throw _privateConstructorUsedError;
+  @override
+  String get description => throw _privateConstructorUsedError;
+  @override
+  bool get canSave => throw _privateConstructorUsedError;
+  @override
+  bool get isModified => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$ScheduleEditViewModelCopyWith<_ScheduleEditViewModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/presentation/view/view_model/schedule_list_element_model.dart
+++ b/lib/presentation/view/view_model/schedule_list_element_model.dart
@@ -5,6 +5,7 @@ part 'schedule_list_element_model.freezed.dart';
 @freezed
 abstract class ScheduleListElementModel with _$ScheduleListElementModel {
   const factory ScheduleListElementModel({
+    required final int scheduleId,
     required final bool isWholeDay,
     required final DateTime startDateTime,
     required final DateTime endDateTime,

--- a/lib/presentation/view/view_model/schedule_list_element_model.freezed.dart
+++ b/lib/presentation/view/view_model/schedule_list_element_model.freezed.dart
@@ -16,6 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$ScheduleListElementModel {
+  int get scheduleId => throw _privateConstructorUsedError;
   bool get isWholeDay => throw _privateConstructorUsedError;
   DateTime get startDateTime => throw _privateConstructorUsedError;
   DateTime get endDateTime => throw _privateConstructorUsedError;
@@ -33,7 +34,8 @@ abstract class $ScheduleListElementModelCopyWith<$Res> {
           $Res Function(ScheduleListElementModel) then) =
       _$ScheduleListElementModelCopyWithImpl<$Res>;
   $Res call(
-      {bool isWholeDay,
+      {int scheduleId,
+      bool isWholeDay,
       DateTime startDateTime,
       DateTime endDateTime,
       List<String> dateTimeTexts,
@@ -51,6 +53,7 @@ class _$ScheduleListElementModelCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? scheduleId = freezed,
     Object? isWholeDay = freezed,
     Object? startDateTime = freezed,
     Object? endDateTime = freezed,
@@ -58,6 +61,10 @@ class _$ScheduleListElementModelCopyWithImpl<$Res>
     Object? scheduleTitle = freezed,
   }) {
     return _then(_value.copyWith(
+      scheduleId: scheduleId == freezed
+          ? _value.scheduleId
+          : scheduleId // ignore: cast_nullable_to_non_nullable
+              as int,
       isWholeDay: isWholeDay == freezed
           ? _value.isWholeDay
           : isWholeDay // ignore: cast_nullable_to_non_nullable
@@ -90,7 +97,8 @@ abstract class _$ScheduleListElementModelCopyWith<$Res>
       __$ScheduleListElementModelCopyWithImpl<$Res>;
   @override
   $Res call(
-      {bool isWholeDay,
+      {int scheduleId,
+      bool isWholeDay,
       DateTime startDateTime,
       DateTime endDateTime,
       List<String> dateTimeTexts,
@@ -111,6 +119,7 @@ class __$ScheduleListElementModelCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? scheduleId = freezed,
     Object? isWholeDay = freezed,
     Object? startDateTime = freezed,
     Object? endDateTime = freezed,
@@ -118,6 +127,10 @@ class __$ScheduleListElementModelCopyWithImpl<$Res>
     Object? scheduleTitle = freezed,
   }) {
     return _then(_ScheduleListElementModel(
+      scheduleId: scheduleId == freezed
+          ? _value.scheduleId
+          : scheduleId // ignore: cast_nullable_to_non_nullable
+              as int,
       isWholeDay: isWholeDay == freezed
           ? _value.isWholeDay
           : isWholeDay // ignore: cast_nullable_to_non_nullable
@@ -146,13 +159,16 @@ class __$ScheduleListElementModelCopyWithImpl<$Res>
 
 class _$_ScheduleListElementModel implements _ScheduleListElementModel {
   const _$_ScheduleListElementModel(
-      {required this.isWholeDay,
+      {required this.scheduleId,
+      required this.isWholeDay,
       required this.startDateTime,
       required this.endDateTime,
       required final List<String> dateTimeTexts,
       required this.scheduleTitle})
       : _dateTimeTexts = dateTimeTexts;
 
+  @override
+  final int scheduleId;
   @override
   final bool isWholeDay;
   @override
@@ -171,7 +187,7 @@ class _$_ScheduleListElementModel implements _ScheduleListElementModel {
 
   @override
   String toString() {
-    return 'ScheduleListElementModel(isWholeDay: $isWholeDay, startDateTime: $startDateTime, endDateTime: $endDateTime, dateTimeTexts: $dateTimeTexts, scheduleTitle: $scheduleTitle)';
+    return 'ScheduleListElementModel(scheduleId: $scheduleId, isWholeDay: $isWholeDay, startDateTime: $startDateTime, endDateTime: $endDateTime, dateTimeTexts: $dateTimeTexts, scheduleTitle: $scheduleTitle)';
   }
 
   @override
@@ -179,6 +195,8 @@ class _$_ScheduleListElementModel implements _ScheduleListElementModel {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _ScheduleListElementModel &&
+            const DeepCollectionEquality()
+                .equals(other.scheduleId, scheduleId) &&
             const DeepCollectionEquality()
                 .equals(other.isWholeDay, isWholeDay) &&
             const DeepCollectionEquality()
@@ -194,6 +212,7 @@ class _$_ScheduleListElementModel implements _ScheduleListElementModel {
   @override
   int get hashCode => Object.hash(
       runtimeType,
+      const DeepCollectionEquality().hash(scheduleId),
       const DeepCollectionEquality().hash(isWholeDay),
       const DeepCollectionEquality().hash(startDateTime),
       const DeepCollectionEquality().hash(endDateTime),
@@ -209,12 +228,15 @@ class _$_ScheduleListElementModel implements _ScheduleListElementModel {
 
 abstract class _ScheduleListElementModel implements ScheduleListElementModel {
   const factory _ScheduleListElementModel(
-      {required final bool isWholeDay,
+      {required final int scheduleId,
+      required final bool isWholeDay,
       required final DateTime startDateTime,
       required final DateTime endDateTime,
       required final List<String> dateTimeTexts,
       required final String scheduleTitle}) = _$_ScheduleListElementModel;
 
+  @override
+  int get scheduleId => throw _privateConstructorUsedError;
   @override
   bool get isWholeDay => throw _privateConstructorUsedError;
   @override

--- a/lib/presentation/view/view_model/schedule_list_view_model.dart
+++ b/lib/presentation/view/view_model/schedule_list_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:schedule_management_app/presentation/view/view_model/schedule_list_element_model.dart';
@@ -8,6 +9,9 @@ part 'schedule_list_view_model.freezed.dart';
 abstract class ScheduleListViewModel with _$ScheduleListViewModel {
   const factory ScheduleListViewModel({
     required final DateTime selectedDateTime,
+    required final String selectedDateTimeText,
+    required final String weekDayText,
+    required final Color weekDayColor,
     required final List<ScheduleListElementModel> scheduleElements,
   }) = _ScheduleListViewModel;
 }

--- a/lib/presentation/view/view_model/schedule_list_view_model.dart
+++ b/lib/presentation/view/view_model/schedule_list_view_model.dart
@@ -7,7 +7,7 @@ part 'schedule_list_view_model.freezed.dart';
 @freezed
 abstract class ScheduleListViewModel with _$ScheduleListViewModel {
   const factory ScheduleListViewModel({
-    required final DateTime selectedDay,
+    required final DateTime selectedDateTime,
     required final List<ScheduleListElementModel> scheduleElements,
   }) = _ScheduleListViewModel;
 }

--- a/lib/presentation/view/view_model/schedule_list_view_model.freezed.dart
+++ b/lib/presentation/view/view_model/schedule_list_view_model.freezed.dart
@@ -16,7 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$ScheduleListViewModel {
-  DateTime get selectedDay => throw _privateConstructorUsedError;
+  DateTime get selectedDateTime => throw _privateConstructorUsedError;
   List<ScheduleListElementModel> get scheduleElements =>
       throw _privateConstructorUsedError;
 
@@ -31,7 +31,8 @@ abstract class $ScheduleListViewModelCopyWith<$Res> {
           $Res Function(ScheduleListViewModel) then) =
       _$ScheduleListViewModelCopyWithImpl<$Res>;
   $Res call(
-      {DateTime selectedDay, List<ScheduleListElementModel> scheduleElements});
+      {DateTime selectedDateTime,
+      List<ScheduleListElementModel> scheduleElements});
 }
 
 /// @nodoc
@@ -45,13 +46,13 @@ class _$ScheduleListViewModelCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? selectedDay = freezed,
+    Object? selectedDateTime = freezed,
     Object? scheduleElements = freezed,
   }) {
     return _then(_value.copyWith(
-      selectedDay: selectedDay == freezed
-          ? _value.selectedDay
-          : selectedDay // ignore: cast_nullable_to_non_nullable
+      selectedDateTime: selectedDateTime == freezed
+          ? _value.selectedDateTime
+          : selectedDateTime // ignore: cast_nullable_to_non_nullable
               as DateTime,
       scheduleElements: scheduleElements == freezed
           ? _value.scheduleElements
@@ -69,7 +70,8 @@ abstract class _$ScheduleListViewModelCopyWith<$Res>
       __$ScheduleListViewModelCopyWithImpl<$Res>;
   @override
   $Res call(
-      {DateTime selectedDay, List<ScheduleListElementModel> scheduleElements});
+      {DateTime selectedDateTime,
+      List<ScheduleListElementModel> scheduleElements});
 }
 
 /// @nodoc
@@ -85,13 +87,13 @@ class __$ScheduleListViewModelCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? selectedDay = freezed,
+    Object? selectedDateTime = freezed,
     Object? scheduleElements = freezed,
   }) {
     return _then(_ScheduleListViewModel(
-      selectedDay: selectedDay == freezed
-          ? _value.selectedDay
-          : selectedDay // ignore: cast_nullable_to_non_nullable
+      selectedDateTime: selectedDateTime == freezed
+          ? _value.selectedDateTime
+          : selectedDateTime // ignore: cast_nullable_to_non_nullable
               as DateTime,
       scheduleElements: scheduleElements == freezed
           ? _value.scheduleElements
@@ -107,12 +109,12 @@ class _$_ScheduleListViewModel
     with DiagnosticableTreeMixin
     implements _ScheduleListViewModel {
   const _$_ScheduleListViewModel(
-      {required this.selectedDay,
+      {required this.selectedDateTime,
       required final List<ScheduleListElementModel> scheduleElements})
       : _scheduleElements = scheduleElements;
 
   @override
-  final DateTime selectedDay;
+  final DateTime selectedDateTime;
   final List<ScheduleListElementModel> _scheduleElements;
   @override
   List<ScheduleListElementModel> get scheduleElements {
@@ -122,7 +124,7 @@ class _$_ScheduleListViewModel
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'ScheduleListViewModel(selectedDay: $selectedDay, scheduleElements: $scheduleElements)';
+    return 'ScheduleListViewModel(selectedDateTime: $selectedDateTime, scheduleElements: $scheduleElements)';
   }
 
   @override
@@ -130,7 +132,7 @@ class _$_ScheduleListViewModel
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('type', 'ScheduleListViewModel'))
-      ..add(DiagnosticsProperty('selectedDay', selectedDay))
+      ..add(DiagnosticsProperty('selectedDateTime', selectedDateTime))
       ..add(DiagnosticsProperty('scheduleElements', scheduleElements));
   }
 
@@ -140,7 +142,7 @@ class _$_ScheduleListViewModel
         (other.runtimeType == runtimeType &&
             other is _ScheduleListViewModel &&
             const DeepCollectionEquality()
-                .equals(other.selectedDay, selectedDay) &&
+                .equals(other.selectedDateTime, selectedDateTime) &&
             const DeepCollectionEquality()
                 .equals(other.scheduleElements, scheduleElements));
   }
@@ -148,7 +150,7 @@ class _$_ScheduleListViewModel
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(selectedDay),
+      const DeepCollectionEquality().hash(selectedDateTime),
       const DeepCollectionEquality().hash(scheduleElements));
 
   @JsonKey(ignore: true)
@@ -160,12 +162,12 @@ class _$_ScheduleListViewModel
 
 abstract class _ScheduleListViewModel implements ScheduleListViewModel {
   const factory _ScheduleListViewModel(
-          {required final DateTime selectedDay,
+          {required final DateTime selectedDateTime,
           required final List<ScheduleListElementModel> scheduleElements}) =
       _$_ScheduleListViewModel;
 
   @override
-  DateTime get selectedDay => throw _privateConstructorUsedError;
+  DateTime get selectedDateTime => throw _privateConstructorUsedError;
   @override
   List<ScheduleListElementModel> get scheduleElements =>
       throw _privateConstructorUsedError;

--- a/lib/presentation/view/view_model/schedule_list_view_model.freezed.dart
+++ b/lib/presentation/view/view_model/schedule_list_view_model.freezed.dart
@@ -17,6 +17,9 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$ScheduleListViewModel {
   DateTime get selectedDateTime => throw _privateConstructorUsedError;
+  String get selectedDateTimeText => throw _privateConstructorUsedError;
+  String get weekDayText => throw _privateConstructorUsedError;
+  Color get weekDayColor => throw _privateConstructorUsedError;
   List<ScheduleListElementModel> get scheduleElements =>
       throw _privateConstructorUsedError;
 
@@ -32,6 +35,9 @@ abstract class $ScheduleListViewModelCopyWith<$Res> {
       _$ScheduleListViewModelCopyWithImpl<$Res>;
   $Res call(
       {DateTime selectedDateTime,
+      String selectedDateTimeText,
+      String weekDayText,
+      Color weekDayColor,
       List<ScheduleListElementModel> scheduleElements});
 }
 
@@ -47,6 +53,9 @@ class _$ScheduleListViewModelCopyWithImpl<$Res>
   @override
   $Res call({
     Object? selectedDateTime = freezed,
+    Object? selectedDateTimeText = freezed,
+    Object? weekDayText = freezed,
+    Object? weekDayColor = freezed,
     Object? scheduleElements = freezed,
   }) {
     return _then(_value.copyWith(
@@ -54,6 +63,18 @@ class _$ScheduleListViewModelCopyWithImpl<$Res>
           ? _value.selectedDateTime
           : selectedDateTime // ignore: cast_nullable_to_non_nullable
               as DateTime,
+      selectedDateTimeText: selectedDateTimeText == freezed
+          ? _value.selectedDateTimeText
+          : selectedDateTimeText // ignore: cast_nullable_to_non_nullable
+              as String,
+      weekDayText: weekDayText == freezed
+          ? _value.weekDayText
+          : weekDayText // ignore: cast_nullable_to_non_nullable
+              as String,
+      weekDayColor: weekDayColor == freezed
+          ? _value.weekDayColor
+          : weekDayColor // ignore: cast_nullable_to_non_nullable
+              as Color,
       scheduleElements: scheduleElements == freezed
           ? _value.scheduleElements
           : scheduleElements // ignore: cast_nullable_to_non_nullable
@@ -71,6 +92,9 @@ abstract class _$ScheduleListViewModelCopyWith<$Res>
   @override
   $Res call(
       {DateTime selectedDateTime,
+      String selectedDateTimeText,
+      String weekDayText,
+      Color weekDayColor,
       List<ScheduleListElementModel> scheduleElements});
 }
 
@@ -88,6 +112,9 @@ class __$ScheduleListViewModelCopyWithImpl<$Res>
   @override
   $Res call({
     Object? selectedDateTime = freezed,
+    Object? selectedDateTimeText = freezed,
+    Object? weekDayText = freezed,
+    Object? weekDayColor = freezed,
     Object? scheduleElements = freezed,
   }) {
     return _then(_ScheduleListViewModel(
@@ -95,6 +122,18 @@ class __$ScheduleListViewModelCopyWithImpl<$Res>
           ? _value.selectedDateTime
           : selectedDateTime // ignore: cast_nullable_to_non_nullable
               as DateTime,
+      selectedDateTimeText: selectedDateTimeText == freezed
+          ? _value.selectedDateTimeText
+          : selectedDateTimeText // ignore: cast_nullable_to_non_nullable
+              as String,
+      weekDayText: weekDayText == freezed
+          ? _value.weekDayText
+          : weekDayText // ignore: cast_nullable_to_non_nullable
+              as String,
+      weekDayColor: weekDayColor == freezed
+          ? _value.weekDayColor
+          : weekDayColor // ignore: cast_nullable_to_non_nullable
+              as Color,
       scheduleElements: scheduleElements == freezed
           ? _value.scheduleElements
           : scheduleElements // ignore: cast_nullable_to_non_nullable
@@ -110,11 +149,20 @@ class _$_ScheduleListViewModel
     implements _ScheduleListViewModel {
   const _$_ScheduleListViewModel(
       {required this.selectedDateTime,
+      required this.selectedDateTimeText,
+      required this.weekDayText,
+      required this.weekDayColor,
       required final List<ScheduleListElementModel> scheduleElements})
       : _scheduleElements = scheduleElements;
 
   @override
   final DateTime selectedDateTime;
+  @override
+  final String selectedDateTimeText;
+  @override
+  final String weekDayText;
+  @override
+  final Color weekDayColor;
   final List<ScheduleListElementModel> _scheduleElements;
   @override
   List<ScheduleListElementModel> get scheduleElements {
@@ -124,7 +172,7 @@ class _$_ScheduleListViewModel
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'ScheduleListViewModel(selectedDateTime: $selectedDateTime, scheduleElements: $scheduleElements)';
+    return 'ScheduleListViewModel(selectedDateTime: $selectedDateTime, selectedDateTimeText: $selectedDateTimeText, weekDayText: $weekDayText, weekDayColor: $weekDayColor, scheduleElements: $scheduleElements)';
   }
 
   @override
@@ -133,6 +181,9 @@ class _$_ScheduleListViewModel
     properties
       ..add(DiagnosticsProperty('type', 'ScheduleListViewModel'))
       ..add(DiagnosticsProperty('selectedDateTime', selectedDateTime))
+      ..add(DiagnosticsProperty('selectedDateTimeText', selectedDateTimeText))
+      ..add(DiagnosticsProperty('weekDayText', weekDayText))
+      ..add(DiagnosticsProperty('weekDayColor', weekDayColor))
       ..add(DiagnosticsProperty('scheduleElements', scheduleElements));
   }
 
@@ -144,6 +195,12 @@ class _$_ScheduleListViewModel
             const DeepCollectionEquality()
                 .equals(other.selectedDateTime, selectedDateTime) &&
             const DeepCollectionEquality()
+                .equals(other.selectedDateTimeText, selectedDateTimeText) &&
+            const DeepCollectionEquality()
+                .equals(other.weekDayText, weekDayText) &&
+            const DeepCollectionEquality()
+                .equals(other.weekDayColor, weekDayColor) &&
+            const DeepCollectionEquality()
                 .equals(other.scheduleElements, scheduleElements));
   }
 
@@ -151,6 +208,9 @@ class _$_ScheduleListViewModel
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(selectedDateTime),
+      const DeepCollectionEquality().hash(selectedDateTimeText),
+      const DeepCollectionEquality().hash(weekDayText),
+      const DeepCollectionEquality().hash(weekDayColor),
       const DeepCollectionEquality().hash(scheduleElements));
 
   @JsonKey(ignore: true)
@@ -163,11 +223,20 @@ class _$_ScheduleListViewModel
 abstract class _ScheduleListViewModel implements ScheduleListViewModel {
   const factory _ScheduleListViewModel(
           {required final DateTime selectedDateTime,
+          required final String selectedDateTimeText,
+          required final String weekDayText,
+          required final Color weekDayColor,
           required final List<ScheduleListElementModel> scheduleElements}) =
       _$_ScheduleListViewModel;
 
   @override
   DateTime get selectedDateTime => throw _privateConstructorUsedError;
+  @override
+  String get selectedDateTimeText => throw _privateConstructorUsedError;
+  @override
+  String get weekDayText => throw _privateConstructorUsedError;
+  @override
+  Color get weekDayColor => throw _privateConstructorUsedError;
   @override
   List<ScheduleListElementModel> get scheduleElements =>
       throw _privateConstructorUsedError;

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -33,7 +33,6 @@ class CalendarDataStore extends _$CalendarDataStore {
   }
 
   Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
-
     return (select(schedules)
           ..where((tbl) {
             final isEqualYear = tbl.startDateTime.year.equals(dateTime.year);

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -34,7 +34,10 @@ class CalendarDataStore extends _$CalendarDataStore {
   }
 
   Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {
-    return (select(schedules)..where((tbl) => tbl.startDateTime.dateEquals(dateTime))).get();
+    return (select(schedules)
+      ..where((tbl) => tbl.startDateTime.dateEquals(dateTime))
+      ..orderBy([(u) => OrderingTerm(expression: u.startDateTime, mode: OrderingMode.asc)]))
+        .get();
   }
 
   Future<Schedule> getScheduleEntry(final int scheduleId) {

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -30,7 +30,7 @@ class CalendarDataStore extends _$CalendarDataStore {
   int get schemaVersion => 1;
 
   Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
-    return (select(schedules)..where((tbl) => tbl.startDateTime.dateEquals(dateTime))).get();
+    return (select(schedules)..where((tbl) => tbl.startDateTime.dateYearMonthEquals(dateTime))).get();
   }
 
   Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -29,13 +29,13 @@ class CalendarDataStore extends _$CalendarDataStore {
   @override
   int get schemaVersion => 1;
 
-  Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
-    return (select(schedules)..where((tbl) => tbl.startDateTime.dateYearMonthEquals(dateTime)))
+  Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) async {
+    return await (select(schedules)..where((tbl) => tbl.startDateTime.dateYearMonthEquals(dateTime)))
         .get();
   }
 
-  Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {
-    return (select(schedules)
+  Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) async {
+    return await (select(schedules)
           ..where((tbl) => tbl.startDateTime.dateEquals(dateTime))
           ..orderBy([
             (entry) => OrderingTerm(expression: entry.isWholeDay, mode: OrderingMode.desc),
@@ -44,8 +44,8 @@ class CalendarDataStore extends _$CalendarDataStore {
         .get();
   }
 
-  Future<Schedule> getScheduleEntry(final int scheduleId) {
-    return (select(schedules)..where((tbl) => tbl.id.equals(scheduleId))).getSingle();
+  Future<Schedule> getScheduleEntry(final int scheduleId) async {
+    return await (select(schedules)..where((tbl) => tbl.id.equals(scheduleId))).getSingle();
   }
 
   Future<int> addSchedule(
@@ -54,8 +54,8 @@ class CalendarDataStore extends _$CalendarDataStore {
     final DateTime startDateTime,
     final DateTime endDateTime,
     final String description,
-  ) {
-    return into(schedules).insert(
+  ) async {
+    return await into(schedules).insert(
       SchedulesCompanion(
         title: Value(title),
         isWholeDay: Value(isWholeDay),
@@ -73,8 +73,8 @@ class CalendarDataStore extends _$CalendarDataStore {
     final DateTime startDateTime,
     final DateTime endDateTime,
     final String description,
-  ) {
-    return (update(schedules)..where((tbl) => tbl.id.equals(schedule.id))).write(
+  ) async {
+    return await (update(schedules)..where((tbl) => tbl.id.equals(schedule.id))).write(
       SchedulesCompanion(
         title: Value(title),
         isWholeDay: Value(isWholeDay),
@@ -85,8 +85,8 @@ class CalendarDataStore extends _$CalendarDataStore {
     );
   }
 
-  Future<void> deleteSchedule(final Schedule schedule) {
-    return (delete(schedules)..where((tbl) => tbl.id.equals(schedule.id))).go();
+  Future<void> deleteSchedule(final Schedule schedule) async {
+    await (delete(schedules)..where((tbl) => tbl.id.equals(schedule.id))).go();
   }
 }
 

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -30,13 +30,17 @@ class CalendarDataStore extends _$CalendarDataStore {
   int get schemaVersion => 1;
 
   Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
-    return (select(schedules)..where((tbl) => tbl.startDateTime.dateYearMonthEquals(dateTime))).get();
+    return (select(schedules)..where((tbl) => tbl.startDateTime.dateYearMonthEquals(dateTime)))
+        .get();
   }
 
   Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {
     return (select(schedules)
-      ..where((tbl) => tbl.startDateTime.dateEquals(dateTime))
-      ..orderBy([(u) => OrderingTerm(expression: u.startDateTime, mode: OrderingMode.asc)]))
+          ..where((tbl) => tbl.startDateTime.dateEquals(dateTime))
+          ..orderBy([
+            (entry) => OrderingTerm(expression: entry.isWholeDay, mode: OrderingMode.desc),
+            (entry) => OrderingTerm(expression: entry.startDateTime, mode: OrderingMode.asc)
+          ]))
         .get();
   }
 

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -28,10 +28,6 @@ class CalendarDataStore extends _$CalendarDataStore {
   @override
   int get schemaVersion => 1;
 
-  Future<Schedule> getScheduleById(final int id) {
-    return (select(schedules)..where((tbl) => tbl.id.equals(id))).getSingle();
-  }
-
   Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
     return (select(schedules)
           ..where((tbl) {
@@ -44,7 +40,6 @@ class CalendarDataStore extends _$CalendarDataStore {
   }
 
   Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {
-
     return (select(schedules)
           ..where((tbl) {
             final isEqualYear = tbl.startDateTime.year.equals(dateTime.year);
@@ -54,6 +49,12 @@ class CalendarDataStore extends _$CalendarDataStore {
             return result;
           }))
         .get();
+  }
+
+  Future<Schedule> getScheduleEntry(final int scheduleId) {
+    return (select(schedules)
+          ..where((tbl) => tbl.id.equals(scheduleId)))
+        .getSingle();
   }
 
   Future<int> addSchedule(

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -32,23 +32,25 @@ class CalendarDataStore extends _$CalendarDataStore {
     return (select(schedules)..where((tbl) => tbl.id.equals(id))).getSingle();
   }
 
-  Future<List<Schedule>> getMonthScheduleEntries(final int year, final int month) {
+  Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
+
     return (select(schedules)
           ..where((tbl) {
-            final isEqualYear = tbl.startDateTime.year.equals(year);
-            final isEqualMonth = tbl.startDateTime.month.equals(month);
+            final isEqualYear = tbl.startDateTime.year.equals(dateTime.year);
+            final isEqualMonth = tbl.startDateTime.month.equals(dateTime.month);
             final result = isEqualYear & isEqualMonth;
             return result;
           }))
         .get();
   }
 
-  Future<List<Schedule>> getDayScheduleEntries(final int year, final int month, final int day) {
+  Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {
+
     return (select(schedules)
           ..where((tbl) {
-            final isEqualYear = tbl.startDateTime.year.equals(year);
-            final isEqualMonth = tbl.startDateTime.month.equals(month);
-            final isEqualDay = tbl.startDateTime.day.equals(day);
+            final isEqualYear = tbl.startDateTime.year.equals(dateTime.year);
+            final isEqualMonth = tbl.startDateTime.month.equals(dateTime.month);
+            final isEqualDay = tbl.startDateTime.day.equals(dateTime.day);
             final result = isEqualYear & isEqualMonth & isEqualDay;
             return result;
           }))

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:schedule_management_app/service/data_store/deep_date_time_expressions.dart';
 
 part 'calendar_data_store.g.dart';
 
@@ -29,32 +30,15 @@ class CalendarDataStore extends _$CalendarDataStore {
   int get schemaVersion => 1;
 
   Future<List<Schedule>> getMonthScheduleEntries(final DateTime dateTime) {
-    return (select(schedules)
-          ..where((tbl) {
-            final isEqualYear = tbl.startDateTime.year.equals(dateTime.year);
-            final isEqualMonth = tbl.startDateTime.month.equals(dateTime.month);
-            final result = isEqualYear & isEqualMonth;
-            return result;
-          }))
-        .get();
+    return (select(schedules)..where((tbl) => tbl.startDateTime.dateEquals(dateTime))).get();
   }
 
   Future<List<Schedule>> getDayScheduleEntries(final DateTime dateTime) {
-    return (select(schedules)
-          ..where((tbl) {
-            final isEqualYear = tbl.startDateTime.year.equals(dateTime.year);
-            final isEqualMonth = tbl.startDateTime.month.equals(dateTime.month);
-            final isEqualDay = tbl.startDateTime.day.equals(dateTime.day);
-            final result = isEqualYear & isEqualMonth & isEqualDay;
-            return result;
-          }))
-        .get();
+    return (select(schedules)..where((tbl) => tbl.startDateTime.dateEquals(dateTime))).get();
   }
 
   Future<Schedule> getScheduleEntry(final int scheduleId) {
-    return (select(schedules)
-          ..where((tbl) => tbl.id.equals(scheduleId)))
-        .getSingle();
+    return (select(schedules)..where((tbl) => tbl.id.equals(scheduleId))).getSingle();
   }
 
   Future<int> addSchedule(

--- a/lib/service/data_store/calendar_data_store.dart
+++ b/lib/service/data_store/calendar_data_store.dart
@@ -94,7 +94,7 @@ class CalendarDataStore extends _$CalendarDataStore {
     );
   }
 
-  Future deleteSchedule(final Schedule schedule) {
+  Future<void> deleteSchedule(final Schedule schedule) {
     return (delete(schedules)..where((tbl) => tbl.id.equals(schedule.id))).go();
   }
 }

--- a/lib/service/data_store/deep_date_time_expressions.dart
+++ b/lib/service/data_store/deep_date_time_expressions.dart
@@ -10,7 +10,7 @@ extension DeepDateTimeExpressions on Expression<DateTime?> {
       [
         this,
         const Constant<String>("unixepoch"),
-        const Constant<String>("localtime")
+        const Constant<String>("localtime"),
       ],
     );
   }
@@ -19,5 +19,9 @@ extension DeepDateTimeExpressions on Expression<DateTime?> {
 extension DeepCompareDateDB on GeneratedColumn<DateTime?> {
   Expression<bool> dateEquals(DateTime value) {
     return dateLocal.equals(value.toIso8601String().substring(0, 10));
+  }
+
+  Expression<bool?> dateYearMonthEquals(DateTime value) {
+    return year.equals(value.year) & month.isBetweenValues(value.month - 1, value.month + 1);
   }
 }

--- a/lib/service/data_store/deep_date_time_expressions.dart
+++ b/lib/service/data_store/deep_date_time_expressions.dart
@@ -1,0 +1,23 @@
+import 'package:drift/drift.dart';
+
+/// DriftのDateTimeがズレる不具合の対処用のExtension
+/// 修正方法参考
+/// https://github.com/simolus3/drift/issues/286#issuecomment-830068149
+extension DeepDateTimeExpressions on Expression<DateTime?> {
+  Expression<String> get dateLocal {
+    return FunctionCallExpression(
+      "DATE",
+      [
+        this,
+        const Constant<String>("unixepoch"),
+        const Constant<String>("localtime")
+      ],
+    );
+  }
+}
+
+extension DeepCompareDateDB on GeneratedColumn<DateTime?> {
+  Expression<bool> dateEquals(DateTime value) {
+    return dateLocal.equals(value.toIso8601String().substring(0, 10));
+  }
+}


### PR DESCRIPTION
## 概要
### 表示
- 予定編集画面の作成に伴い、予定追加画面と同じViewの部分を、ScheduleComponent.dartに共通化
- 登録済みの予定をタップしたら、タイトルなどの各項目に登録済みのデータを表示
### 動作
- 予定を編集し、保存したら予定が更新されるよう対応

## Issue
- https://github.com/curitefl/schedule_management_app/issues/5

## 確認方法
- 予定編集画面を開き、登録していたデータが表示されることを確認します。
- 変更を保存したら、予定一覧画面に反映されることを確認します。

https://user-images.githubusercontent.com/103098702/167801586-327c1766-2dd8-47d6-9d6f-29b9592c956d.mov


