### PR TITLE
予定一覧画面の各予定の間隔を調整。予定追加/編集画面での削除ボタンの見た目の調整。

### DIFF
--- a/lib/presentation/view/component/schedule_component.dart
+++ b/lib/presentation/view/component/schedule_component.dart
@@ -104,11 +104,14 @@ class ScheduleComponent extends StatelessWidget {
                     ),
                     onChanged: _onTitleChanged,
                   ),
-                  SwitchListTile(
+                  ListTile(
                     title: const Text(ScheduleComponentConstants.wholeDay),
-                    value: _isWholeDay,
-                    onChanged: _onWholeDayChanged,
+                    trailing: Switch(
+                      value: _isWholeDay,
+                      onChanged: _onWholeDayChanged,
+                    ),
                   ),
+                  const Divider(height: 8.0,),
                   WidgetFactory.createDatePickerButton(
                     context,
                     ScheduleComponentConstants.start,
@@ -123,6 +126,7 @@ class ScheduleComponent extends StatelessWidget {
                       );
                     },
                   ),
+                  const Divider(height: 8.0,),
                   WidgetFactory.createDatePickerButton(
                     context,
                     ScheduleComponentConstants.end,

--- a/lib/presentation/view/factory/widget_factory.dart
+++ b/lib/presentation/view/factory/widget_factory.dart
@@ -1,25 +1,23 @@
 import 'package:flutter/material.dart';
 
 class WidgetFactory {
-  static Row createDatePickerButton(
+  static ListTile createDatePickerButton(
     final BuildContext context,
     final String title,
     final String dateTimeText,
     final VoidCallback? onPressed,
   ) {
-    return Row(
-      children: [
-        Text(title),
-        TextButton(
-          child: Text(
-            dateTimeText,
-            style: const TextStyle(
-              color: Colors.black,
-            ),
+    return ListTile(
+      title: Text(title),
+      trailing: TextButton(
+        child: Text(
+          dateTimeText,
+          style: const TextStyle(
+            color: Colors.black,
           ),
-          onPressed: onPressed,
         ),
-      ],
+        onPressed: onPressed,
+      ),
     );
   }
 }

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -61,8 +61,7 @@ class ScheduleEditView extends HookConsumerWidget {
     final ScheduleEditPresenter presenter,
     final int scheduleId,
   ) async {
-
-    return await showCupertinoModalPopup(
+    final isDiscard = await showCupertinoModalPopup(
       context: context,
       builder: (BuildContext context) {
         return CupertinoActionSheet(
@@ -70,7 +69,7 @@ class ScheduleEditView extends HookConsumerWidget {
           message: const Text(TextConstants.scheduleEditViewDeleteMessage),
           actions: [
             CupertinoActionSheetAction(
-            isDestructiveAction: true,
+              isDestructiveAction: true,
               onPressed: () async {
                 await presenter.deleteSchedule(scheduleId);
                 Navigator.pop(context, true);
@@ -85,5 +84,6 @@ class ScheduleEditView extends HookConsumerWidget {
         );
       },
     );
+    return isDiscard ?? false;
   }
 }

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -61,9 +61,8 @@ class ScheduleEditView extends HookConsumerWidget {
     final ScheduleEditPresenter presenter,
     final int scheduleId,
   ) async {
-    var isDiscard = false;
 
-    await showCupertinoModalPopup(
+    return await showCupertinoModalPopup(
       context: context,
       builder: (BuildContext context) {
         return CupertinoActionSheet(
@@ -74,19 +73,17 @@ class ScheduleEditView extends HookConsumerWidget {
             isDestructiveAction: true,
               onPressed: () async {
                 await presenter.deleteSchedule(scheduleId);
-                Navigator.pop(context);
-                isDiscard = true;
+                Navigator.pop(context, true);
               },
               child: const Text(TextConstants.scheduleEditViewDeleteConfirm),
             ),
           ],
           cancelButton: CupertinoActionSheetAction(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => Navigator.pop(context, false),
             child: const Text(TextConstants.scheduleEditViewDeleteCancel),
           ),
         );
       },
     );
-    return isDiscard;
   }
 }

--- a/lib/presentation/view/view/schedule_edit_view.dart
+++ b/lib/presentation/view/view/schedule_edit_view.dart
@@ -32,18 +32,26 @@ class ScheduleEditView extends HookConsumerWidget {
       isModified: viewModel.isModified,
       onPressedSave: () async => await presenter.save(ref),
       onDiscard: () => presenter.refreshState(ref),
-      child: TextButton(
-        child: const Text(
-          TextConstants.scheduleEditViewDeleteTitle,
-          maxLines: 1,
-        ),
-        onPressed: () async {
-          final isDiscard = await _showDeletePopup(context, presenter, viewModel.scheduleId);
+      child: ListTile(
+        title: OutlinedButton(
+          child: const Text(
+            TextConstants.scheduleEditViewDeleteTitle,
+            maxLines: 1,
+            style: TextStyle(color: Colors.red),
+          ),
+          style: OutlinedButton.styleFrom(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+          ),
+          onPressed: () async {
+            final isDiscard = await _showDeletePopup(context, presenter, viewModel.scheduleId);
 
-          if(isDiscard) {
-            Navigator.pop(context);
-          }
-        },
+            if (isDiscard) {
+              Navigator.pop(context);
+            }
+          },
+        ),
       ),
     );
   }
@@ -63,6 +71,7 @@ class ScheduleEditView extends HookConsumerWidget {
           message: const Text(TextConstants.scheduleEditViewDeleteMessage),
           actions: [
             CupertinoActionSheetAction(
+            isDestructiveAction: true,
               onPressed: () async {
                 await presenter.deleteSchedule(scheduleId);
                 Navigator.pop(context);
@@ -70,11 +79,11 @@ class ScheduleEditView extends HookConsumerWidget {
               },
               child: const Text(TextConstants.scheduleEditViewDeleteConfirm),
             ),
-            CupertinoActionSheetAction(
-              onPressed: () => Navigator.pop(context),
-              child: const Text(TextConstants.scheduleEditViewDeleteCancel),
-            ),
           ],
+          cancelButton: CupertinoActionSheetAction(
+            onPressed: () => Navigator.pop(context),
+            child: const Text(TextConstants.scheduleEditViewDeleteCancel),
+          ),
         );
       },
     );

--- a/lib/presentation/view/view/schedule_list_view.dart
+++ b/lib/presentation/view/view/schedule_list_view.dart
@@ -52,8 +52,15 @@ class ScheduleListView extends HookConsumerWidget {
       content: SizedBox(
         height: MediaQuery.of(context).size.height / 2.0,
         width: MediaQuery.of(context).size.width - 24.0,
-        child: ListView.builder(
+        child: ListView.separated(
+          padding: const EdgeInsets.all(8.0),
           itemCount: viewModel.scheduleElements.length,
+          separatorBuilder: (BuildContext context, int index) {
+            return const SizedBox(
+              height: 8.0,
+              child: Divider(height: 8.0,),
+            );
+          },
           itemBuilder: (BuildContext context, int index) {
             return Row(
               children: [
@@ -70,7 +77,8 @@ class ScheduleListView extends HookConsumerWidget {
                 Container(
                   height: 50.0,
                   width: 5.0,
-                  color: viewModel.scheduleElements[index].isWholeDay ?  Colors.redAccent : Colors.blue,
+                  color:
+                      viewModel.scheduleElements[index].isWholeDay ? Colors.redAccent : Colors.blue,
                 ),
                 Expanded(
                   child: Align(
@@ -81,8 +89,8 @@ class ScheduleListView extends HookConsumerWidget {
                         overflow: TextOverflow.ellipsis,
                         maxLines: 1,
                       ),
-                      onPressed: () {
-                        presenter.showScheduleEditView(
+                      onPressed: () async {
+                        await presenter.showScheduleEditView(
                             context,
                             viewModel.scheduleElements[index].scheduleId,
                             viewModel.selectedDateTime);


### PR DESCRIPTION
## 概要
- 予定一覧画面で、各予定の間隔を調整
- 予定追加/編集画面での、開始時間/終了時間の配置の間隔を調整、削除ボタンの見た目を調整
## 確認方法
- 予定一覧画面で各予定の間隔が適度に空いていることを確認します
- 予定追加/編集画面での、開始時間/終了時間の位置が、終日スイッチの位置と統一されていることを確認します
- 削除ボタンが赤文字になっていることを確認します
- 削除ボタンを押した後のアクションシートで、削除の文字が赤くなっていることを確認します

https://user-images.githubusercontent.com/103098702/167971846-ac063708-21d3-42d4-a8fe-42c5395d207c.mov


